### PR TITLE
[HOTFIX] Use Node 16 after PNPM added

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,17 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
+      # Read node version from `.nvmrc` file
+      - id: nvmrc
+        uses: browniebroke/read-nvmrc-action@v1
+
+      - uses: actions/setup-node@v1
+        with:
+          # use the output from the action
+          node-version: '${{ steps.nvmrc.outputs.node_version }}'
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+
       # Read the pnpm version from the `.pnpmrc` file
       - name: Read .pnpmrc
         id: pnpm_version


### PR DESCRIPTION
## What
The add of PNPM we lost the correct Node version specified in our `.nvmrc`. See: https://github.com/leaderboardsgg/leaderboard-site/runs/4187624748?check_suite_focus=true#step:7:4

## Link to Issue

Closes https://github.com/speedrun-website/speedrun.website/issues/98

## Acceptance

### Steps for testing
Verify that our CI process no longer warns us about the following:
```
WARN  Unsupported engine: wanted: {"node":">=16.0.0"} (current: {"node":"v14.18.1","pnpm":"6.21.0"})
```
