### PR TITLE
Upgrade Tailwindcss to v3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "postcss": "^8.3.9",
     "prettier": "^2.4.1",
     "pretty-quick": "^3.1.1",
-    "tailwindcss": "^2.2.16",
+    "tailwindcss": "^3.0.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^10.4.0",
     "vue-jest": "^3.0.7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,7 +48,7 @@ specifiers:
   postcss: ^8.3.9
   prettier: ^2.4.1
   pretty-quick: ^3.1.1
-  tailwindcss: ^2.2.16
+  tailwindcss: ^3.0.0
   ts-jest: ^27.0.5
   ts-node: ^10.4.0
   typescript: ^4.4.4
@@ -107,7 +107,7 @@ devDependencies:
   postcss: 8.4.4
   prettier: 2.5.1
   pretty-quick: 3.1.2_prettier@2.5.1
-  tailwindcss: 2.2.19_64e95eea492b78ba1be305e2672c4e19
+  tailwindcss: 3.0.1_64e95eea492b78ba1be305e2672c4e19
   ts-jest: 27.1.0_e53b46d64db598b4003104f45b472342
   ts-node: 10.4.0_typescript@4.5.2
   vue-jest: 3.0.7_6950027468cb1abb3cd6715353f2665b
@@ -11930,6 +11930,41 @@ packages:
       purgecss: 4.1.3
       quick-lru: 5.1.1
       reduce-css-calc: 2.1.8
+      resolve: 1.20.0
+      tmp: 0.2.1
+    transitivePeerDependencies:
+      - ts-node
+    dev: true
+
+  /tailwindcss/3.0.1_64e95eea492b78ba1be305e2672c4e19:
+    resolution: {integrity: sha512-EVDXVZkcueZ77/zfOJw7XkzCuxe5TCiT/S9pw9P183oRzSuwMZ7WO+W/L76jbJQA5qxGeUBJOVOLVBuAUfeZ3g==}
+    engines: {node: '>=12.13.0'}
+    hasBin: true
+    peerDependencies:
+      autoprefixer: ^10.0.2
+      postcss: ^8.0.9
+    dependencies:
+      arg: 5.0.1
+      autoprefixer: 10.4.0_postcss@8.4.4
+      chalk: 4.1.2
+      chokidar: 3.5.2
+      color-name: 1.1.4
+      cosmiconfig: 7.0.1
+      detective: 5.2.0
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.2.7
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      object-hash: 2.2.0
+      postcss: 8.4.4
+      postcss-js: 3.0.3
+      postcss-load-config: 3.1.0_ts-node@10.4.0
+      postcss-nested: 5.0.6_postcss@8.4.4
+      postcss-selector-parser: 6.0.6
+      postcss-value-parser: 4.2.0
+      quick-lru: 5.1.1
       resolve: 1.20.0
       tmp: 0.2.1
     transitivePeerDependencies:


### PR DESCRIPTION
## What

Upgrades Tailwind CSS to v3.0.1

## Link to Issue

N/A (https://github.com/leaderboardsgg/leaderboard-site/pull/145)

## Acceptance

### Steps for testing

- Tests should pass
- Site should still work as usual