### PR TITLE
updated the config to only deal with automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,9 +4,14 @@
   "labels": ["dependencies"],
   "packageRules": [
     {
-      "matchPackagePatterns": ["eslint"],
-      "labels": ["linting"]
+      "description": "Automerge all non Major updates",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
     },
-    { "updateTypes": ["minor", "patch"], "automerge": true }
+    {
+      "description": "Ensure automerge is not on for Major updates",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    }
   ]
 }


### PR DESCRIPTION
## What

Updated the config for Renovate bot to reflect what we want to do with the automerge, and removed the unecessary tagging of ESLint as Linting.

## Acceptance

Only effects Renovate bot.
