### PR TITLE
Disabled tests in Renovate to enable automerging (hopefully)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,10 @@
       "labels": ["linting"]
     },
     { "updateTypes": ["minor", "patch"], "automerge": true }
+  ],
+  "ignoreTests": false,
+  "description": [
+    "The usage of ignoreTests just means that Renovate will ignore its own internal checks of merge readiness,",
+    "this means that we can disable this because we already lock the PRs to need to pass CI before it can succesfully merge."
   ]
 }


### PR DESCRIPTION
## What

Disabled tests in Renovate bot and gave a description as to why 

## Acceptance

Only effects Renovate bot