### PR TITLE
LBGG[Nuxt3]: Add the `build` step into the CI workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Install `node_modules`
         run: pnpm install
 
+      - name: Build the `.nuxt` directory
+        run: pnpm build
+
       - name: Tests
         run: pnpm run test
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,5 +40,7 @@
       "vitest/globals"
     ]
   },
-  "exclude": ["node_modules", ".nuxt", ".output", "dist"]
+  "exclude": ["node_modules", ".nuxt", ".output", "dist"],
+  // https://v3.nuxtjs.org/concepts/typescript
+  "extends": "./.nuxt/tsconfig.json"
 }


### PR DESCRIPTION
## What

In order to keep the auto generated types and component imports from the `.nuxt` directory, we're adding a `build` step in our CI workflow to make sure that those are present during the process.

## Link to Issue

N/A

## Acceptance

### Steps for testing

- [X] CI should pass

### Images

N/A
