### PR TITLE
Migrate testing suite to use `@vue/test-utils` 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -49,6 +49,18 @@
     "arrow-parens": ["error", "always"],
     "comma-dangle": "off",
     "eol-last": ["error", "always"],
+    "import/order": ["error",
+      {
+        "groups": [
+          "builtin",
+          "external",
+          ["internal", "parent", "sibling"],
+          "index",
+          "object",
+          "type"
+        ]
+      }
+    ],
     "semi": "off",
     "space-before-function-paren": "off",
     "tailwindcss/no-custom-classname": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -49,7 +49,8 @@
     "arrow-parens": ["error", "always"],
     "comma-dangle": "off",
     "eol-last": ["error", "always"],
-    "import/order": ["error",
+    "import/order": [
+      "error",
       {
         "groups": [
           "builtin",

--- a/components/blocks/SearchBar/SearchBar.test.ts
+++ b/components/blocks/SearchBar/SearchBar.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { describe, expect, test } from 'vitest'
+
 import { mount } from '@vue/test-utils'
 
 // import { VueNode } from '@vue/test-utils/dist/types'
@@ -8,14 +8,14 @@ import SearchBar from './SearchBar.vue'
 describe('<SearchBar />', () => {
   const SearchBarWrapper = mount(SearchBar)
 
-  test('should render without crashing', () => {
+  it('should render without crashing', () => {
     expect(SearchBarWrapper.isVisible()).toBe(true)
   })
 
   describe('when the search event is emitted', () => {
     const inputValue = 'test'
 
-    test('when the search button is clicked', async () => {
+    it('when the search button is clicked', async () => {
       // on `wrapper.vm` we can access any method or value
       // @ts-expect-error
       SearchBarWrapper.vm.state.input.value = inputValue
@@ -28,7 +28,7 @@ describe('<SearchBar />', () => {
       expect(SearchBarWrapper.emitted()?.search[0][0]).toBe(inputValue)
     })
 
-    test('when the enter key is released', async () => {
+    it('when the enter key is released', async () => {
       // on `wrapper.vm` we can access any method or value
       // @ts-expect-error
       SearchBarWrapper.vm.state.input.value = inputValue

--- a/components/blocks/SiteFooter/SiteFooter.test.ts
+++ b/components/blocks/SiteFooter/SiteFooter.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { mount } from '@vue/test-utils'
 
 import SiteFooter from './SiteFooter.vue'
@@ -6,11 +5,11 @@ import SiteFooter from './SiteFooter.vue'
 describe('<SiteFooter />', () => {
   const SiteFooterWrapper = mount(SiteFooter)
 
-  test('should render without crashing', () => {
+  it('should render without crashing', () => {
     expect(SiteFooterWrapper.isVisible()).toBe(true)
   })
 
-  test('renders correctly with the copyright info', () => {
+  it('renders correctly with the copyright info', () => {
     expect(SiteFooterWrapper.html()).toContain(
       `Copyright ${new Date().getFullYear()}`,
     )

--- a/components/blocks/cards/LogInCard/LogInCard.test.ts
+++ b/components/blocks/cards/LogInCard/LogInCard.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { mount } from '@vue/test-utils'
 import LogInCard from './LogInCard.vue'
 import { FullRequestParams } from 'lib/api/http-client'
@@ -108,7 +107,6 @@ describe('<LogInCard />', () => {
       await getByTestId(wrapper, 'login-button').trigger('click')
 
       const apiCalls = fetchMock.mock.calls as fetchMockCall[]
-      // console.log(apiCalls)
       expect(apiCalls?.[0]?.length).toBe(2)
 
       const loginApiCall = apiCalls[0]

--- a/components/blocks/cards/LogInCard/LogInCard.test.ts
+++ b/components/blocks/cards/LogInCard/LogInCard.test.ts
@@ -1,8 +1,8 @@
 /* eslint-disable no-console */
 import { mount } from '@vue/test-utils'
-
 import LogInCard from './LogInCard.vue'
-import { FullRequestParams } from 'root/lib/api/http-client'
+import { FullRequestParams } from 'lib/api/http-client'
+import { getByTestId, getHTMLElement } from 'testUtils'
 
 const token = 'jwt-token'
 type fetchMockCall = [string, FullRequestParams]
@@ -17,17 +17,17 @@ describe('<LogInCard />', () => {
     fetchMock.mockResponseOnce(JSON.stringify({ token }))
   })
 
-  const LogInCardWrapper = mount(LogInCard)
-
   it('should render without crashing', () => {
-    expect(LogInCardWrapper.isVisible()).toBe(true)
+    const wrapper = mount(LogInCard)
+
+    expect(wrapper.isVisible()).toBe(true)
   })
 
   describe('when the close button is clicked', () => {
     it('should emit the close event', async () => {
       const wrapper = mount(LogInCard)
 
-      const closeButton = wrapper.get('[data-testid="close-button"]')
+      const closeButton = getByTestId(wrapper, 'close-button')
 
       await closeButton.trigger('click')
 
@@ -38,13 +38,15 @@ describe('<LogInCard />', () => {
   describe('when the hide/show button is clicked', () => {
     it('changes the password input type to be text', async () => {
       const wrapper = mount(LogInCard)
-      const passwordInput = wrapper.get('[data-testid="password-input"]')
+      const passwordInputElement = getHTMLElement(
+        getByTestId(wrapper, 'password-input'),
+      ) as HTMLInputElement
 
-      expect(passwordInput.attributes('type')).toBe('password')
+      expect(passwordInputElement.type).toBe('password')
 
-      await wrapper.get('[data-testid="hide-show-button"]').trigger('click')
+      await getByTestId(wrapper, 'hide-show-button').trigger('click')
 
-      expect(passwordInput.attributes('type')).toBe('text')
+      expect(passwordInputElement.type).toBe('text')
     })
   })
 
@@ -52,7 +54,7 @@ describe('<LogInCard />', () => {
     it('emits the close event', async () => {
       const wrapper = mount(LogInCard)
 
-      await wrapper.get('[data-testid="password-input"]').trigger('keyup.enter')
+      await getByTestId(wrapper, 'password-input').trigger('keyup.enter')
 
       expect(wrapper.emitted().close).toBeTruthy()
     })
@@ -65,7 +67,7 @@ describe('<LogInCard />', () => {
     it('emits the close event', async () => {
       const wrapper = mount(LogInCard)
 
-      await wrapper.get('[data-testid="login-button"]').trigger('click')
+      await getByTestId(wrapper, 'login-button').trigger('click')
 
       expect(wrapper.emitted().close).toBeTruthy()
     })
@@ -73,20 +75,21 @@ describe('<LogInCard />', () => {
     it('clears the state', async () => {
       const wrapper = mount(LogInCard)
 
-      const emailInput = wrapper.get('[data-testid="email-input"]')
-      const passwordInput = wrapper.get('[data-testid="password-input"]')
+      const emailInput = getByTestId(wrapper, 'email-input')
+      const passwordInput = getByTestId(wrapper, 'password-input')
 
       await emailInput.setValue(emailAddress)
       await passwordInput.setValue(password)
 
-      const emailInputElement = emailInput.getRootNodes()[0] as HTMLInputElement
-      const passwordInputElement =
-        passwordInput.getRootNodes()[0] as HTMLInputElement
+      const emailInputElement = getHTMLElement(emailInput) as HTMLInputElement
+      const passwordInputElement = getHTMLElement(
+        passwordInput,
+      ) as HTMLInputElement
 
       expect(emailInputElement.value).toBe(emailAddress)
       expect(passwordInputElement.value).toBe(password)
 
-      await wrapper.get('[data-testid="login-button"]').trigger('click')
+      await getByTestId(wrapper, 'login-button').trigger('click')
 
       expect(emailInputElement.value).toBe('')
       expect(passwordInputElement.value).toBe('')
@@ -96,16 +99,16 @@ describe('<LogInCard />', () => {
     it.skip('calls the api', async () => {
       const wrapper = mount(LogInCard)
 
-      const emailInput = wrapper.get('[data-testid="email-input"]')
-      const passwordInput = wrapper.get('[data-testid="password-input"]')
+      const emailInput = getByTestId(wrapper, 'email-input')
+      const passwordInput = getByTestId(wrapper, 'password-input')
 
       await emailInput.setValue(emailAddress)
       await passwordInput.setValue(password)
 
-      await wrapper.get('[data-testid="login-button"]').trigger('click')
+      await getByTestId(wrapper, 'login-button').trigger('click')
 
       const apiCalls = fetchMock.mock.calls as fetchMockCall[]
-      console.log(apiCalls)
+      // console.log(apiCalls)
       expect(apiCalls?.[0]?.length).toBe(2)
 
       const loginApiCall = apiCalls[0]
@@ -137,7 +140,7 @@ describe('<LogInCard />', () => {
     it('emits the sign up click event', async () => {
       const wrapper = mount(LogInCard)
 
-      await wrapper.get('[data-testid="sign-up-button"]').trigger('click')
+      await getByTestId(wrapper, 'sign-up-button').trigger('click')
 
       expect(wrapper.emitted().signUpClick).toBeTruthy()
     })

--- a/components/blocks/cards/LogInCard/LogInCard.test.ts
+++ b/components/blocks/cards/LogInCard/LogInCard.test.ts
@@ -1,148 +1,145 @@
-import { describe, expect, test } from 'vitest'
+/* eslint-disable no-console */
 import { mount } from '@vue/test-utils'
 
-// import SearchBar from './SearchBar.vue'
-
 import LogInCard from './LogInCard.vue'
-// import { FullRequestParams } from 'root/lib/api/http-client'
+import { FullRequestParams } from 'root/lib/api/http-client'
 
-// const token = 'jwt-token'
+const token = 'jwt-token'
+type fetchMockCall = [string, FullRequestParams]
 
-// type fetchMockCall = [string, FullRequestParams]
-
-// vi.mock('#app', () => ({
-//   useRuntimeConfig: () => ({
-//     public: {
-//       BACKEND_BASE_URL: process.env.BACKEND_BASE_URL,
-//     },
-//   }),
-// }))
-
-// afterEach(() => {
-//   fetchMock.resetMocks()
-//   vi.restoreAllMocks()
-// })
+afterEach(() => {
+  fetchMock.resetMocks()
+  vi.restoreAllMocks()
+})
 
 describe('<LogInCard />', () => {
-  // beforeEach(() => {
-  //   fetchMock.mockResponseOnce(JSON.stringify({ token }))
-  // })
+  beforeEach(() => {
+    fetchMock.mockResponseOnce(JSON.stringify({ token }))
+  })
 
   const LogInCardWrapper = mount(LogInCard)
 
-  test('should render without crashing', () => {
+  it('should render without crashing', () => {
     expect(LogInCardWrapper.isVisible()).toBe(true)
   })
 
-  // describe('when the close button is clicked', () => {
-  //   test('should emit the close event', async () => {
-  //     const { emitted, getByTestId } = stubbedRender(LogInCard)
+  describe('when the close button is clicked', () => {
+    it('should emit the close event', async () => {
+      const wrapper = mount(LogInCard)
 
-  //     await fireEvent.click(getByTestId('close-button'))
+      const closeButton = wrapper.get('[data-testid="close-button"]')
 
-  //     expect(emitted().close).toBeTruthy()
-  //   })
-  // })
+      await closeButton.trigger('click')
 
-  // describe('when the hide/show button is clicked', () => {
-  //   test('changes the password input type to be text', async () => {
-  //     const { getByTestId } = stubbedRender(LogInCard)
-  //     const passwordInput: HTMLInputElement = getByTestId('password-input')
+      expect(wrapper.emitted().close).toBeTruthy()
+    })
+  })
 
-  //     expect(passwordInput.type).toBe('password')
+  describe('when the hide/show button is clicked', () => {
+    it('changes the password input type to be text', async () => {
+      const wrapper = mount(LogInCard)
+      const passwordInput = wrapper.get('[data-testid="password-input"]')
 
-  //     await fireEvent.click(getByTestId('hide-show-button'))
+      expect(passwordInput.attributes('type')).toBe('password')
 
-  //     expect(passwordInput.type).toBe('text')
-  //   })
-  // })
+      await wrapper.get('[data-testid="hide-show-button"]').trigger('click')
 
-  // describe('when enter key is released on the password input field', () => {
-  //   test('emits the close event', async () => {
-  //     const { emitted, getByTestId } = stubbedRender(LogInCard)
+      expect(passwordInput.attributes('type')).toBe('text')
+    })
+  })
 
-  //     await fireEvent.type(getByTestId('password-input'), '{enter}')
+  describe('when enter key is released on the password input field', () => {
+    it('emits the close event', async () => {
+      const wrapper = mount(LogInCard)
 
-  //     expect(emitted().close).toBeTruthy()
-  //   })
-  // })
+      await wrapper.get('[data-testid="password-input"]').trigger('keyup.enter')
 
-  // describe('when the login button is clicked', () => {
-  //   const emailAddress = 'strongbad@homestarrunner.com'
-  //   const password = 'homestarsux'
+      expect(wrapper.emitted().close).toBeTruthy()
+    })
+  })
 
-  //   test('emits the close event', async () => {
-  //     const { emitted, getByTestId } = stubbedRender(LogInCard)
+  describe('when the login button is clicked', () => {
+    const emailAddress = 'strongbad@homestarrunner.com'
+    const password = 'homestarsux'
 
-  //     await fireEvent.click(getByTestId('login-button'))
+    it('emits the close event', async () => {
+      const wrapper = mount(LogInCard)
 
-  //     expect(emitted().close).toBeTruthy()
-  //   })
+      await wrapper.get('[data-testid="login-button"]').trigger('click')
 
-  //   test('clears the state', async () => {
-  //     const { getByTestId } = stubbedRender(LogInCard)
+      expect(wrapper.emitted().close).toBeTruthy()
+    })
 
-  //     const emailInput: HTMLInputElement = getByTestId('email-input')
-  //     const passwordInput: HTMLInputElement = getByTestId('password-input')
+    it('clears the state', async () => {
+      const wrapper = mount(LogInCard)
 
-  //     await fireEvent.type(emailInput, emailAddress)
-  //     await fireEvent.type(passwordInput, password)
+      const emailInput = wrapper.get('[data-testid="email-input"]')
+      const passwordInput = wrapper.get('[data-testid="password-input"]')
 
-  //     expect(emailInput.value).toBe(emailAddress)
-  //     expect(passwordInput.value).toBe(password)
+      await emailInput.setValue(emailAddress)
+      await passwordInput.setValue(password)
 
-  //     await fireEvent.click(getByTestId('login-button'))
+      const emailInputElement = emailInput.getRootNodes()[0] as HTMLInputElement
+      const passwordInputElement =
+        passwordInput.getRootNodes()[0] as HTMLInputElement
 
-  //     expect(emailInput.value).toBe('')
-  //     expect(passwordInput.value).toBe('')
-  //   })
+      expect(emailInputElement.value).toBe(emailAddress)
+      expect(passwordInputElement.value).toBe(password)
 
-  //   test('calls the api', async () => {
-  //     const { getByTestId } = stubbedRender(LogInCard)
+      await wrapper.get('[data-testid="login-button"]').trigger('click')
 
-  //     const emailInput: HTMLInputElement = getByTestId('email-input')
-  //     const passwordInput: HTMLInputElement = getByTestId('password-input')
+      expect(emailInputElement.value).toBe('')
+      expect(passwordInputElement.value).toBe('')
+    })
 
-  //     await fireEvent.type(emailInput, emailAddress)
-  //     await fireEvent.type(passwordInput, password)
+    // this test is still failing
+    it.skip('calls the api', async () => {
+      const wrapper = mount(LogInCard)
 
-  //     await fireEvent.click(getByTestId('login-button'))
+      const emailInput = wrapper.get('[data-testid="email-input"]')
+      const passwordInput = wrapper.get('[data-testid="password-input"]')
 
-  //     const apiCalls = fetchMock.mock.calls as fetchMockCall[]
-  //     expect(apiCalls.length).toBe(2)
+      await emailInput.setValue(emailAddress)
+      await passwordInput.setValue(password)
 
-  //     const loginApiCall = apiCalls[0]
-  //     expect(loginApiCall?.[0]).toBe(
-  //       `${process.env.BACKEND_BASE_URL}/api/Users/login`,
-  //     )
-  //     expect(loginApiCall?.[1].method).toBe('POST')
-  //     expect(loginApiCall?.[1].body).toEqual(
-  //       JSON.stringify({
-  //         email: emailAddress,
-  //         password,
-  //       }),
-  //     )
+      await wrapper.get('[data-testid="login-button"]').trigger('click')
 
-  //     const meApiCall = apiCalls[1]
-  //     expect(meApiCall?.[0]).toBe(
-  //       `${process.env.BACKEND_BASE_URL}/api/Users/me`,
-  //     )
-  //     expect(meApiCall?.[1].method).toBe('GET')
+      const apiCalls = fetchMock.mock.calls as fetchMockCall[]
+      console.log(apiCalls)
+      expect(apiCalls?.[0]?.length).toBe(2)
 
-  //     const headers = meApiCall?.[1]?.headers as Record<string, string>
-  //     expect(headers).toBeDefined()
-  //     expect(Object.keys(headers)).toContain('Authorization')
-  //     expect(headers.Authorization).toEqual(`Bearer ${token}`)
-  //   })
-  // })
+      const loginApiCall = apiCalls[0]
+      expect(loginApiCall?.[0]).toBe(
+        `${process.env.BACKEND_BASE_URL}/api/Users/login`,
+      )
+      expect(loginApiCall?.[1].method).toBe('POST')
+      expect(loginApiCall?.[1].body).toEqual(
+        JSON.stringify({
+          email: emailAddress,
+          password,
+        }),
+      )
 
-  // describe('when the sign up button is clicked', () => {
-  //   test('emits the sign up click event', async () => {
-  //     const { emitted, getByTestId } = stubbedRender(LogInCard)
+      const meApiCall = apiCalls[1]
+      expect(meApiCall?.[0]).toBe(
+        `${process.env.BACKEND_BASE_URL}/api/Users/me`,
+      )
+      expect(meApiCall?.[1].method).toBe('GET')
 
-  //     await fireEvent.click(getByTestId('sign-up-button'))
+      const headers = meApiCall?.[1]?.headers as Record<string, string>
+      expect(headers).toBeDefined()
+      expect(Object.keys(headers)).toContain('Authorization')
+      expect(headers.Authorization).toEqual(`Bearer ${token}`)
+    })
+  })
 
-  //     expect(emitted().signUpClick).toBeTruthy()
-  //   })
-  // })
+  describe('when the sign up button is clicked', () => {
+    it('emits the sign up click event', async () => {
+      const wrapper = mount(LogInCard)
+
+      await wrapper.get('[data-testid="sign-up-button"]').trigger('click')
+
+      expect(wrapper.emitted().signUpClick).toBeTruthy()
+    })
+  })
 })

--- a/components/blocks/cards/SignUpCard/SignUpCard.test.ts
+++ b/components/blocks/cards/SignUpCard/SignUpCard.test.ts
@@ -1,117 +1,126 @@
+/* eslint-disable no-console */
 import { mount } from '@vue/test-utils'
-
 import SignUpCard from './SignUpCard.vue'
+import { getByTestId, getHTMLElement } from 'testUtils'
 
 describe('<SignUpCard />', () => {
-  const SignUpCardWrapper = mount(SignUpCard)
-
   it('should render without crashing', () => {
-    expect(SignUpCardWrapper.isVisible()).toBe(true)
+    const wrapper = mount(SignUpCard)
+
+    expect(wrapper.isVisible()).toBe(true)
   })
 
-  // describe('when the close button is clicked', () => {
-  //   it('should close the SignUpCard', async () => {
-  //     await SignUpCardWrapper.get('[data-testid="close-button"]').trigger(
-  //       'click',
-  //     )
+  describe('when the close button is clicked', () => {
+    it('should emit the close event', async () => {
+      const wrapper = mount(SignUpCard)
 
-  //     expect(SignUpCardWrapper.isVisible()).toBe(false)
-  //   })
-  // })
+      await getByTestId(wrapper, 'close-button').trigger('click')
+
+      expect(wrapper.emitted().close).toBeTruthy()
+    })
+  })
 
   describe('when the hide/show button is clicked', () => {
     it('changes the password input type to be text', async () => {
-      const passwordInput = SignUpCardWrapper.get(
-        '[data-testid="password-input"]',
-      )
-      const passwordConfirmInput = SignUpCardWrapper.get(
-        '[data-testid="password-confirm-input"]',
-      )
+      const wrapper = mount(SignUpCard)
 
-      expect(passwordInput.attributes('type')).toBe('password')
-      expect(passwordConfirmInput.attributes('type')).toBe('password')
+      const passwordInputElement = getHTMLElement(
+        getByTestId(wrapper, 'password-input'),
+      ) as HTMLInputElement
+      const passwordConfirmInputElement = getHTMLElement(
+        getByTestId(wrapper, 'password-confirm-input'),
+      ) as HTMLInputElement
 
-      await SignUpCardWrapper.get('[data-testid="hide-show-button"]').trigger(
-        'click',
-      )
+      expect(passwordInputElement.type).toBe('password')
+      expect(passwordConfirmInputElement.type).toBe('password')
 
-      expect(passwordInput.attributes('type')).toBe('text')
-      expect(passwordConfirmInput.attributes('type')).toBe('text')
+      await getByTestId(wrapper, 'hide-show-button').trigger('click')
+
+      expect(passwordInputElement.type).toBe('text')
+      expect(passwordConfirmInputElement.type).toBe('text')
     })
   })
 
   describe('when the login button is clicked', () => {
     it('emits the log in click event', async () => {
-      await SignUpCardWrapper.get('[data-testid="login-button"]').trigger(
-        'click',
-      )
+      const wrapper = mount(SignUpCard)
 
-      expect(SignUpCardWrapper.emitted()).toHaveProperty('logInClick')
+      await getByTestId(wrapper, 'login-button').trigger('click')
+
+      expect(wrapper.emitted()).toHaveProperty('logInClick')
     })
   })
 
-  // describe('when the sign up button is clicked', () => {
-  //   // const emailAddress = 'strongbad@homestarrunner.com'
-  //   // const password = 'homestarsux'
-  //   // const username = 'strongbad'
+  describe('when the sign up button is clicked', () => {
+    const emailAddress = 'strongbad@homestarrunner.com'
+    const password = 'homestarsux'
+    const username = 'strongbad'
 
-  //   it('emits the sign up click event', async () => {
-  //     await SignUpCardWrapper.get('[data-testid="sign-up-button"]').trigger(
-  //       'click',
-  //     )
+    it('emits the sign up click event', async () => {
+      const wrapper = mount(SignUpCard)
 
-  //     expect(SignUpCardWrapper.emitted().signUpClick).toBeTruthy()
-  //     // expect(emitted().signUpClick).toBeTruthy()
-  //   })
+      await getByTestId(wrapper, 'sign-up-button').trigger('click')
 
-  //   it('clears the state', async () => {
-  //     const { getByTestId } = stubbedRender(SignUpCard)
-  //     const emailInput: HTMLInputElement = getByTestId('email-input')
-  //     const passwordInput: HTMLInputElement = getByTestId('password-input')
-  //     const passwordConfirmInput: HTMLInputElement = getByTestId(
-  //       'password-confirm-input',
-  //     )
-  //     const usernameInput: HTMLInputElement = getByTestId('username-input')
-  //     await fireEvent.type(emailInput, emailAddress)
-  //     await fireEvent.type(usernameInput, username)
-  //     await fireEvent.type(passwordInput, password)
-  //     await fireEvent.type(passwordConfirmInput, password)
-  //     expect(emailInput.value).toBe(emailAddress)
-  //     expect(usernameInput.value).toBe(username)
-  //     expect(passwordInput.value).toBe(password)
-  //     expect(passwordConfirmInput.value).toBe(password)
-  //     await fireEvent.click(getByTestId('sign-up-button'))
-  //     expect(emailInput.value).toBe('')
-  //     expect(usernameInput.value).toBe('')
-  //     expect(passwordInput.value).toBe('')
-  //     expect(passwordConfirmInput.value).toBe('')
-  //   })
-  //   it('calls the api', async () => {
-  //     const { getByTestId } = stubbedRender(SignUpCard)
-  //     const emailInput: HTMLInputElement = getByTestId('email-input')
-  //     const passwordInput: HTMLInputElement = getByTestId('password-input')
-  //     const passwordConfirmInput: HTMLInputElement = getByTestId(
-  //       'password-confirm-input',
-  //     )
-  //     const usernameInput: HTMLInputElement = getByTestId('username-input')
-  //     await fireEvent.type(emailInput, emailAddress)
-  //     await fireEvent.type(usernameInput, username)
-  //     await fireEvent.type(passwordInput, password)
-  //     await fireEvent.type(passwordConfirmInput, password)
-  //     await fireEvent.click(getByTestId('sign-up-button'))
-  //     const apiCall = fetchMock.mock.calls[0]
-  //     expect(apiCall?.[0]).toEqual(
-  //       `${process.env.BACKEND_BASE_URL}/api/Users/register`,
-  //     )
-  //     expect(apiCall?.[1]?.method).toEqual('POST')
-  //     expect(apiCall?.[1]?.body).toEqual(
-  //       JSON.stringify({
-  //         email: emailAddress,
-  //         password,
-  //         passwordConfirm: password,
-  //         username,
-  //       }),
-  //     )
-  //   })
-  //   })
+      expect(wrapper.emitted().signUpClick).toBeTruthy()
+    })
+
+    it('clears the state', async () => {
+      const wrapper = mount(SignUpCard)
+
+      const emailInputElement = getHTMLElement(
+        getByTestId(wrapper, 'email-input'),
+      ) as HTMLInputElement
+      const passwordInputElement = getHTMLElement(
+        getByTestId(wrapper, 'password-input'),
+      ) as HTMLInputElement
+      const passwordConfirmInputElement = getHTMLElement(
+        getByTestId(wrapper, 'password-confirm-input'),
+      ) as HTMLInputElement
+      const usernameInputElement = getHTMLElement(
+        getByTestId(wrapper, 'username-input'),
+      ) as HTMLInputElement
+
+      await getByTestId(wrapper, 'email-input').setValue(emailAddress)
+      await getByTestId(wrapper, 'username-input').setValue(username)
+      await getByTestId(wrapper, 'password-input').setValue(password)
+      await getByTestId(wrapper, 'password-confirm-input').setValue(password)
+
+      expect(emailInputElement.value).toBe(emailAddress)
+      expect(usernameInputElement.value).toBe(username)
+      expect(passwordInputElement.value).toBe(password)
+      expect(passwordConfirmInputElement.value).toBe(password)
+
+      await getByTestId(wrapper, 'sign-up-button').trigger('click')
+
+      expect(emailInputElement.value).toBe('')
+      expect(usernameInputElement.value).toBe('')
+      expect(passwordInputElement.value).toBe('')
+      expect(passwordConfirmInputElement.value).toBe('')
+    })
+
+    // this test is still failing
+    it.skip('calls the api', async () => {
+      const wrapper = mount(SignUpCard)
+
+      await getByTestId(wrapper, 'email-input').setValue(emailAddress)
+      await getByTestId(wrapper, 'username-input').setValue(username)
+      await getByTestId(wrapper, 'password-input').setValue(password)
+      await getByTestId(wrapper, 'password-confirm-input').setValue(password)
+      await getByTestId(wrapper, 'sign-up-button').trigger('click')
+
+      const apiCall = fetchMock.mock.calls[0]
+      expect(apiCall?.[0]).toEqual(
+        `${process.env.BACKEND_BASE_URL}/api/Users/register`,
+      )
+      expect(apiCall?.[1]?.method).toEqual('POST')
+      expect(apiCall?.[1]?.body).toEqual(
+        JSON.stringify({
+          email: emailAddress,
+          password,
+          passwordConfirm: password,
+          username,
+        }),
+      )
+    })
+  })
 })

--- a/components/blocks/cards/SignUpCard/SignUpCard.test.ts
+++ b/components/blocks/cards/SignUpCard/SignUpCard.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { mount } from '@vue/test-utils'
 
 import SignUpCard from './SignUpCard.vue'
@@ -6,12 +5,12 @@ import SignUpCard from './SignUpCard.vue'
 describe('<SignUpCard />', () => {
   const SignUpCardWrapper = mount(SignUpCard)
 
-  test('should render without crashing', () => {
+  it('should render without crashing', () => {
     expect(SignUpCardWrapper.isVisible()).toBe(true)
   })
 
   // describe('when the close button is clicked', () => {
-  //   test('should close the SignUpCard', async () => {
+  //   it('should close the SignUpCard', async () => {
   //     await SignUpCardWrapper.get('[data-testid="close-button"]').trigger(
   //       'click',
   //     )
@@ -21,7 +20,7 @@ describe('<SignUpCard />', () => {
   // })
 
   describe('when the hide/show button is clicked', () => {
-    test('changes the password input type to be text', async () => {
+    it('changes the password input type to be text', async () => {
       const passwordInput = SignUpCardWrapper.get(
         '[data-testid="password-input"]',
       )
@@ -42,7 +41,7 @@ describe('<SignUpCard />', () => {
   })
 
   describe('when the login button is clicked', () => {
-    test('emits the log in click event', async () => {
+    it('emits the log in click event', async () => {
       await SignUpCardWrapper.get('[data-testid="login-button"]').trigger(
         'click',
       )
@@ -56,7 +55,7 @@ describe('<SignUpCard />', () => {
   //   // const password = 'homestarsux'
   //   // const username = 'strongbad'
 
-  //   test('emits the sign up click event', async () => {
+  //   it('emits the sign up click event', async () => {
   //     await SignUpCardWrapper.get('[data-testid="sign-up-button"]').trigger(
   //       'click',
   //     )
@@ -65,7 +64,7 @@ describe('<SignUpCard />', () => {
   //     // expect(emitted().signUpClick).toBeTruthy()
   //   })
 
-  //   test('clears the state', async () => {
+  //   it('clears the state', async () => {
   //     const { getByTestId } = stubbedRender(SignUpCard)
   //     const emailInput: HTMLInputElement = getByTestId('email-input')
   //     const passwordInput: HTMLInputElement = getByTestId('password-input')
@@ -87,7 +86,7 @@ describe('<SignUpCard />', () => {
   //     expect(passwordInput.value).toBe('')
   //     expect(passwordConfirmInput.value).toBe('')
   //   })
-  //   test('calls the api', async () => {
+  //   it('calls the api', async () => {
   //     const { getByTestId } = stubbedRender(SignUpCard)
   //     const emailInput: HTMLInputElement = getByTestId('email-input')
   //     const passwordInput: HTMLInputElement = getByTestId('password-input')

--- a/components/blocks/cards/SignUpCard/SignUpCard.test.ts
+++ b/components/blocks/cards/SignUpCard/SignUpCard.test.ts
@@ -1,7 +1,11 @@
-/* eslint-disable no-console */
 import { mount } from '@vue/test-utils'
-import SignUpCard from './SignUpCard.vue'
 import { getByTestId, getHTMLElement } from 'testUtils'
+import SignUpCard from './SignUpCard.vue'
+
+afterEach(() => {
+  fetchMock.resetMocks()
+  vi.restoreAllMocks()
+})
 
 describe('<SignUpCard />', () => {
   it('should render without crashing', () => {
@@ -98,8 +102,7 @@ describe('<SignUpCard />', () => {
       expect(passwordConfirmInputElement.value).toBe('')
     })
 
-    // this test is still failing
-    it.skip('calls the api', async () => {
+    it('calls the api', async () => {
       const wrapper = mount(SignUpCard)
 
       await getByTestId(wrapper, 'email-input').setValue(emailAddress)

--- a/components/blocks/nav/SiteNavbar/SiteNavbar.test.ts
+++ b/components/blocks/nav/SiteNavbar/SiteNavbar.test.ts
@@ -1,9 +1,6 @@
-/* eslint-disable no-console */
-// import { ref } from 'vue'
 import { mount } from '@vue/test-utils'
 import * as apiComposables from 'composables/api'
 import { useCurrentUser } from 'composables/useCurrentUser'
-// import { User } from 'lib/api/data-contracts'
 import { getByTestId } from 'testUtils'
 import SiteNavbar from './SiteNavbar.vue'
 
@@ -53,19 +50,8 @@ describe('<SiteNavbar />', () => {
     })
   })
 
-  // this is failing
-  describe.skip('when a user is logged in', () => {
+  describe('when a user is logged in', () => {
     beforeEach(() => {
-      // vi.stubGlobal(
-      //   'useState',
-      //   () => (_stateId: string) =>
-      //     ref<User>({
-      //       admin: true,
-      //       email: 'admin@leaderboards.gg',
-      //       username: 'lbgg_admin',
-      //     }),
-      // )
-
       const currentUser = useCurrentUser()
       currentUser.value = {
         admin: true,

--- a/components/blocks/nav/SiteNavbar/SiteNavbar.test.ts
+++ b/components/blocks/nav/SiteNavbar/SiteNavbar.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, test, vi, afterEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 
 import SiteNavbar from './SiteNavbar.vue'
@@ -17,12 +16,12 @@ describe('<SiteNavbar />', () => {
     },
   })
 
-  test('should render without crashing', () => {
+  it('should render without crashing', () => {
     expect(SiteNavbarWrapper.isVisible()).toBe(true)
   })
 
   describe('when no user is logged in', () => {
-    test('should render the login/sign up buttons', () => {
+    it('should render the login/sign up buttons', () => {
       expect(
         SiteNavbarWrapper.get(
           '[data-testid="site-navbar-login-button"]',
@@ -37,7 +36,7 @@ describe('<SiteNavbar />', () => {
     })
 
     describe('when the login button is clicked', () => {
-      test('should bring up the login card', () => {
+      it('should bring up the login card', () => {
         SiteNavbarWrapper.get(
           '[data-testid="site-navbar-login-button"]',
         ).trigger('click')
@@ -49,7 +48,7 @@ describe('<SiteNavbar />', () => {
     })
 
     describe('when the sign up button is clicked', () => {
-      test('should bring up the signup card', () => {
+      it('should bring up the signup card', () => {
         SiteNavbarWrapper.get(
           '[data-testid="site-navbar-sign-up-button"]',
         ).trigger('click')
@@ -71,7 +70,7 @@ describe('<SiteNavbar />', () => {
   //     },
   //   })
 
-  //   test('should render the logout button', () => {
+  //   it('should render the logout button', () => {
   //     expect(
   //       /* eslint-disable */
   //       // prettier-ignore
@@ -85,7 +84,7 @@ describe('<SiteNavbar />', () => {
   // describe('when the logout button is clicked', () => {
   //   const useLogoutUserSpy = vi.spyOn(apiComposables, 'useLogoutUser')
 
-  //   test('should log out the user', async () => {
+  //   it('should log out the user', async () => {
   //     const { getByTestId } = stubbedRender(SiteNavbar)
 
   //     await fireEvent.click(getByTestId('site-navbar-logout-button'))

--- a/components/blocks/nav/SiteNavbar/SiteNavbar.test.ts
+++ b/components/blocks/nav/SiteNavbar/SiteNavbar.test.ts
@@ -1,5 +1,10 @@
+/* eslint-disable no-console */
+// import { ref } from 'vue'
 import { mount } from '@vue/test-utils'
-
+import * as apiComposables from 'composables/api'
+import { useCurrentUser } from 'composables/useCurrentUser'
+// import { User } from 'lib/api/data-contracts'
+import { getByTestId } from 'testUtils'
 import SiteNavbar from './SiteNavbar.vue'
 
 afterEach(() => {
@@ -8,89 +13,85 @@ afterEach(() => {
 })
 
 describe('<SiteNavbar />', () => {
-  const SiteNavbarWrapper = mount(SiteNavbar, {
-    global: {
-      mocks: {
-        $t: (msg: any) => msg,
-      },
-    },
-  })
-
   it('should render without crashing', () => {
-    expect(SiteNavbarWrapper.isVisible()).toBe(true)
+    const wrapper = mount(SiteNavbar)
+
+    expect(wrapper.isVisible()).toBe(true)
   })
 
   describe('when no user is logged in', () => {
     it('should render the login/sign up buttons', () => {
-      expect(
-        SiteNavbarWrapper.get(
-          '[data-testid="site-navbar-login-button"]',
-        ).isVisible(),
-      ).toBe(true)
+      const wrapper = mount(SiteNavbar)
+
+      expect(getByTestId(wrapper, 'site-navbar-login-button').isVisible()).toBe(
+        true,
+      )
 
       expect(
-        SiteNavbarWrapper.get(
-          '[data-testid="site-navbar-sign-up-button"]',
-        ).isVisible(),
+        getByTestId(wrapper, 'site-navbar-sign-up-button').isVisible(),
       ).toBe(true)
     })
 
     describe('when the login button is clicked', () => {
       it('should bring up the login card', () => {
-        SiteNavbarWrapper.get(
-          '[data-testid="site-navbar-login-button"]',
-        ).trigger('click')
+        const wrapper = mount(SiteNavbar)
 
-        expect(
-          SiteNavbarWrapper.get('[data-testid="log-in-card"]').isVisible(),
-        ).toBe(true)
+        getByTestId(wrapper, 'site-navbar-login-button').trigger('click')
+
+        expect(getByTestId(wrapper, 'log-in-card').isVisible()).toBe(true)
       })
     })
 
     describe('when the sign up button is clicked', () => {
       it('should bring up the signup card', () => {
-        SiteNavbarWrapper.get(
-          '[data-testid="site-navbar-sign-up-button"]',
-        ).trigger('click')
+        const wrapper = mount(SiteNavbar)
 
-        expect(
-          SiteNavbarWrapper.get('[data-testid="sign-up-card"]').isVisible(),
-        ).toBe(true)
+        getByTestId(wrapper, 'site-navbar-sign-up-button').trigger('click')
+
+        expect(getByTestId(wrapper, 'sign-up-card').isVisible()).toBe(true)
       })
     })
   })
 
-  // Needs to be changed in the future anyways so 😬😬😬
-  // describe('when a user is logged in', async () => {
-  //   await SiteNavbarWrapper.setre({
-  //     currentUser: {
-  //       admin: true,
-  //       email: 'admin@leaderboards.gg',
-  //       username: 'lbgg_admin',
-  //     },
-  //   })
+  // this is failing
+  describe.skip('when a user is logged in', () => {
+    beforeEach(() => {
+      // vi.stubGlobal(
+      //   'useState',
+      //   () => (_stateId: string) =>
+      //     ref<User>({
+      //       admin: true,
+      //       email: 'admin@leaderboards.gg',
+      //       username: 'lbgg_admin',
+      //     }),
+      // )
 
-  //   it('should render the logout button', () => {
-  //     expect(
-  //       /* eslint-disable */
-  //       // prettier-ignore
-  //       SiteNavbarWrapper.get(
-  //         '[data-testid="site-navbar-logout-button"]'
-  //         /* eslint-enable */
-  //       ).isVisible(),
-  //     ).toBe(true)
-  //   })
+      const currentUser = useCurrentUser()
+      currentUser.value = {
+        admin: true,
+        email: 'admin@leaderboards.gg',
+        username: 'lbgg_admin',
+      }
+    })
 
-  // describe('when the logout button is clicked', () => {
-  //   const useLogoutUserSpy = vi.spyOn(apiComposables, 'useLogoutUser')
+    it('should render the logout button', () => {
+      const wrapper = mount(SiteNavbar)
 
-  //   it('should log out the user', async () => {
-  //     const { getByTestId } = stubbedRender(SiteNavbar)
+      expect(
+        getByTestId(wrapper, 'site-navbar-logout-button').isVisible(),
+      ).toBe(true)
+    })
 
-  //     await fireEvent.click(getByTestId('site-navbar-logout-button'))
+    describe('when the logout button is clicked', () => {
+      const useLogoutUserSpy = vi.spyOn(apiComposables, 'useLogoutUser')
 
-  //     expect(useLogoutUserSpy).toHaveBeenCalled()
-  //   })
-  // })
-  // })
+      it('should log out the user', async () => {
+        const wrapper = mount(SiteNavbar)
+
+        await getByTestId(wrapper, 'site-navbar-logout-button').trigger('click')
+
+        expect(useLogoutUserSpy).toHaveBeenCalled()
+      })
+    })
+  })
 })

--- a/components/blocks/nav/SiteNavbar/SiteNavbar.vue
+++ b/components/blocks/nav/SiteNavbar/SiteNavbar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, reactive, ref } from 'vue'
+import { computed, reactive } from 'vue'
 import NavLinks from 'elements/nav/NavLinks/NavLinks.vue'
 import LogoutButton from 'elements/buttons/LogoutButton/LogoutButton.vue'
 import SignUpButton from 'elements/buttons/SignUpButton/SignUpButton.vue'
@@ -9,7 +9,7 @@ import SignUpCard from 'blocks/cards/SignUpCard/SignUpCard.vue'
 import BaseModal from 'elements/modals/BaseModal/BaseModal.vue'
 import SearchBar from 'blocks/SearchBar/SearchBar.vue'
 import { useLogoutUser } from 'composables/api'
-import { User } from 'lib/api/data-contracts'
+import { useCurrentUser } from 'composables/useCurrentUser'
 
 interface NavbarState {
   mobileNavIsActive: boolean
@@ -23,11 +23,7 @@ const state: NavbarState = reactive({
   showModal: false,
 })
 
-const currentUser = ref<User>({
-  admin: false,
-  email: '',
-  username: '',
-})
+const currentUser = useCurrentUser()
 const loggedIn = computed(
   () => !!currentUser.value?.username && currentUser.value?.username !== '',
 )

--- a/components/elements/buttons/ButtonLink/ButtonLink.test.ts
+++ b/components/elements/buttons/ButtonLink/ButtonLink.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { mount } from '@vue/test-utils'
 
 import ButtonLink from './ButtonLink.vue'
@@ -7,7 +6,7 @@ describe('<ButtonLink />', () => {
   const defaultAttrs = { class: 'custom-link' }
   const defaultProps = { to: 'https://www.test.com/' }
 
-  test('should render without crashing', () => {
+  it('should render without crashing', () => {
     const ButtonLinkWrapper = mount(ButtonLink, {
       attrs: defaultAttrs,
       props: defaultProps,
@@ -17,7 +16,7 @@ describe('<ButtonLink />', () => {
     expect(ButtonLinkWrapper.isVisible()).toBe(true)
   })
 
-  test('renders with the correct <slot />', () => {
+  it('renders with the correct <slot />', () => {
     const ButtonLinkWrapper = mount(ButtonLink, {
       attrs: defaultAttrs,
       props: defaultProps,
@@ -26,7 +25,7 @@ describe('<ButtonLink />', () => {
     expect(ButtonLinkWrapper.html()).toContain('Any%')
   })
 
-  test('renders with the passed link', () => {
+  it('renders with the passed link', () => {
     const ButtonLinkWrapper = mount(ButtonLink, {
       attrs: defaultAttrs,
       props: defaultProps,
@@ -38,7 +37,7 @@ describe('<ButtonLink />', () => {
     expect(link.attributes('to')).toBe('https://www.test.com/')
   })
 
-  test('renders with the custom classnames', () => {
+  it('renders with the custom classnames', () => {
     const ButtonLinkWrapper = mount(ButtonLink, {
       attrs: {
         ...defaultAttrs,

--- a/components/elements/buttons/HideShowPassword/HideShowPassword.test.ts
+++ b/components/elements/buttons/HideShowPassword/HideShowPassword.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { mount } from '@vue/test-utils'
 
 import HideShowPassword from './HideShowPassword.vue'
@@ -6,7 +5,7 @@ import HideShowPassword from './HideShowPassword.vue'
 describe('<HideShowPassword />', () => {
   const HideShowPasswordWrapper = mount(HideShowPassword)
 
-  test('should render without crashing', () => {
+  it('should render without crashing', () => {
     expect(HideShowPasswordWrapper.isVisible()).toBe(true)
   })
 
@@ -20,7 +19,7 @@ describe('<HideShowPassword />', () => {
     '[data-testid="visible-eye-icon"]',
   )
   describe('Visible eye, hidden eye, and the button', () => {
-    test('should render without crashing', () => {
+    it('should render without crashing', () => {
       expect(passwordButton.isVisible()).toBe(true)
       expect(hiddenEyeIcon.isVisible()).toBe(true)
       expect(visibleEyeIcon.isVisible()).toBe(true)
@@ -28,7 +27,7 @@ describe('<HideShowPassword />', () => {
   })
 
   describe('when clicking the button', () => {
-    test('should toggle the state', async () => {
+    it('should toggle the state', async () => {
       expect(hiddenEyeIcon.html()).not.toContain('style="display: none;')
       expect(visibleEyeIcon.html()).toContain('style="display: none;')
 
@@ -41,7 +40,7 @@ describe('<HideShowPassword />', () => {
 
   //  this contains the previous flip so we need to do the opposite
   describe('when the button is focus and the enter key up event is triggered', () => {
-    test('should toggle the state', async () => {
+    it('should toggle the state', async () => {
       expect(hiddenEyeIcon.html()).toContain('style="display: none;')
       expect(visibleEyeIcon.html()).not.toContain('style="display: none;')
 

--- a/components/elements/buttons/HideShowPassword/HideShowPassword.test.ts
+++ b/components/elements/buttons/HideShowPassword/HideShowPassword.test.ts
@@ -1,25 +1,21 @@
 import { mount } from '@vue/test-utils'
-
 import HideShowPassword from './HideShowPassword.vue'
+import { getByTestId, getHTMLElement } from 'testUtils'
 
 describe('<HideShowPassword />', () => {
-  const HideShowPasswordWrapper = mount(HideShowPassword)
-
   it('should render without crashing', () => {
-    expect(HideShowPasswordWrapper.isVisible()).toBe(true)
+    const wrapper = mount(HideShowPassword)
+
+    expect(wrapper.isVisible()).toBe(true)
   })
 
-  const passwordButton = HideShowPasswordWrapper.get(
-    '[data-testid="hide-show-password-button"]',
-  )
-  const hiddenEyeIcon = HideShowPasswordWrapper.get(
-    '[data-testid="hidden-eye-icon"]',
-  )
-  const visibleEyeIcon = HideShowPasswordWrapper.get(
-    '[data-testid="visible-eye-icon"]',
-  )
   describe('Visible eye, hidden eye, and the button', () => {
     it('should render without crashing', () => {
+      const wrapper = mount(HideShowPassword)
+      const passwordButton = getByTestId(wrapper, 'hide-show-password-button')
+      const hiddenEyeIcon = getByTestId(wrapper, 'hidden-eye-icon')
+      const visibleEyeIcon = getByTestId(wrapper, 'visible-eye-icon')
+
       expect(passwordButton.isVisible()).toBe(true)
       expect(hiddenEyeIcon.isVisible()).toBe(true)
       expect(visibleEyeIcon.isVisible()).toBe(true)
@@ -28,26 +24,43 @@ describe('<HideShowPassword />', () => {
 
   describe('when clicking the button', () => {
     it('should toggle the state', async () => {
-      expect(hiddenEyeIcon.html()).not.toContain('style="display: none;')
-      expect(visibleEyeIcon.html()).toContain('style="display: none;')
+      const wrapper = mount(HideShowPassword)
+      const hiddenEyeIconElement = getHTMLElement(
+        getByTestId(wrapper, 'hidden-eye-icon'),
+      )
+      const visibleEyeIconElement = getHTMLElement(
+        getByTestId(wrapper, 'visible-eye-icon'),
+      )
 
-      await passwordButton.trigger('click')
+      expect(hiddenEyeIconElement.style.display).not.toBe('none')
+      expect(visibleEyeIconElement.style.display).toBe('none')
 
-      expect(hiddenEyeIcon.html()).toContain('style="display: none;')
-      expect(visibleEyeIcon.html()).not.toContain('style="display: none;')
+      await getByTestId(wrapper, 'hide-show-password-button').trigger('click')
+
+      expect(hiddenEyeIconElement.style.display).toBe('none')
+      expect(visibleEyeIconElement.style.display).not.toBe('none')
     })
   })
 
-  //  this contains the previous flip so we need to do the opposite
   describe('when the button is focus and the enter key up event is triggered', () => {
     it('should toggle the state', async () => {
-      expect(hiddenEyeIcon.html()).toContain('style="display: none;')
-      expect(visibleEyeIcon.html()).not.toContain('style="display: none;')
+      const wrapper = mount(HideShowPassword)
+      const hiddenEyeIconElement = getHTMLElement(
+        getByTestId(wrapper, 'hidden-eye-icon'),
+      )
+      const visibleEyeIconElement = getHTMLElement(
+        getByTestId(wrapper, 'visible-eye-icon'),
+      )
 
-      await passwordButton.trigger('keyup.enter')
+      expect(hiddenEyeIconElement.style.display).not.toBe('none')
+      expect(visibleEyeIconElement.style.display).toBe('none')
 
-      expect(hiddenEyeIcon.html()).not.toContain('style="display: none;')
-      expect(visibleEyeIcon.html()).toContain('style="display: none;')
+      await getByTestId(wrapper, 'hide-show-password-button').trigger(
+        'keyup.enter',
+      )
+
+      expect(hiddenEyeIconElement.style.display).toBe('none')
+      expect(visibleEyeIconElement.style.display).not.toBe('none')
     })
   })
 })

--- a/components/elements/modals/BaseModal/BaseModal.test.ts
+++ b/components/elements/modals/BaseModal/BaseModal.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { mount } from '@vue/test-utils'
 
 import BaseModal from './BaseModal.vue'
@@ -8,22 +7,22 @@ describe('<BaseModal />', () => {
     slots: { default: 'Modal content' },
   })
 
-  test('should render without crashing', () => {
+  it('should render without crashing', () => {
     expect(BaseModalWrapper.isVisible()).toBe(true)
   })
 
-  test('renders the correct <slot />', () => {
+  it('renders the correct <slot />', () => {
     expect(BaseModalWrapper.html()).toContain('Modal content')
   })
 
   describe('when the close event is emitted', () => {
-    test('when the close button is clicked', async () => {
+    it('when the close button is clicked', async () => {
       await BaseModalWrapper.find('button').trigger('click')
 
       expect(BaseModalWrapper.emitted().close).toHaveLength(1)
     })
 
-    test('when the escape key is released', async () => {
+    it('when the escape key is released', async () => {
       await BaseModalWrapper.find('button').trigger('keydown.esc')
 
       expect(BaseModalWrapper.emitted().close).toHaveLength(2)

--- a/components/elements/nav/NavLinks/NavLink/NavLink.test.ts
+++ b/components/elements/nav/NavLinks/NavLink/NavLink.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { mount } from '@vue/test-utils'
 
 import NavLink from './NavLink.vue'
@@ -12,7 +11,7 @@ describe('<NavLink />', () => {
     slots: { default: 'Games' },
   })
 
-  test('should render without crashing', () => {
+  it('should render without crashing', () => {
     expect(NavLinkWrapper.isVisible()).toBe(true)
   })
 })

--- a/components/elements/nav/NavLinks/NavLinks.test.ts
+++ b/components/elements/nav/NavLinks/NavLinks.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { mount } from '@vue/test-utils'
 
 import NavLinks from './NavLinks.vue'
@@ -16,11 +15,11 @@ describe('<NavLinks />', () => {
     props,
   })
 
-  test('should render without crashing', () => {
+  it('should render without crashing', () => {
     expect(NavLinksWrapper.isVisible()).toBe(true)
   })
 
-  test('should render the same amount of <NavLink /> components as there are items in the navLinks props', () => {
+  it('should render the same amount of <NavLink /> components as there are items in the navLinks props', () => {
     props.navLinks.forEach((navLink) => {
       expect(NavLinksWrapper.html()).toContain(navLink.name)
     })

--- a/composables/api/useLoginUser.ts
+++ b/composables/api/useLoginUser.ts
@@ -25,12 +25,17 @@ export const useLoginUser = async (
   try {
     const authResponse = await userClient.usersLoginCreate(requestData)
 
+    /* eslint-disable no-console */
+    console.table(authResponse)
+
     if (authResponse.ok) {
       authToken.value = authResponse.data.token
 
       const userResponse = await userClient.usersMeList({
         headers: { Authorization: `Bearer ${authToken.value}` },
       })
+
+      console.table(userResponse)
 
       if (userResponse.ok) {
         currentUser.value = userResponse.data

--- a/composables/api/useLoginUser.ts
+++ b/composables/api/useLoginUser.ts
@@ -1,9 +1,9 @@
 import { ref } from 'vue'
 import { useCurrentUser } from 'composables/useCurrentUser'
 import { useSessionToken } from 'composables/useSessionToken'
-import type { LoginRequest, ProblemDetails } from 'lib/api/data-contracts'
 import { Users } from 'lib/api/Users'
 import { isProblemDetails } from 'lib/helpers'
+import type { LoginRequest, ProblemDetails } from 'lib/api/data-contracts'
 
 interface LoginUserResponse {
   loading: boolean
@@ -25,17 +25,12 @@ export const useLoginUser = async (
   try {
     const authResponse = await userClient.usersLoginCreate(requestData)
 
-    /* eslint-disable no-console */
-    console.table(authResponse)
-
     if (authResponse.ok) {
       authToken.value = authResponse.data.token
 
       const userResponse = await userClient.usersMeList({
         headers: { Authorization: `Bearer ${authToken.value}` },
       })
-
-      console.table(userResponse)
 
       if (userResponse.ok) {
         currentUser.value = userResponse.data

--- a/composables/api/useRegisterUser.ts
+++ b/composables/api/useRegisterUser.ts
@@ -1,11 +1,11 @@
 import { ref } from 'vue'
+import { Users } from 'lib/api/Users'
+import { isProblemDetails } from 'lib/helpers'
 import type {
   ProblemDetails,
   RegisterRequest,
   User,
 } from 'lib/api/data-contracts'
-import { Users } from 'lib/api/Users'
-import { isProblemDetails } from 'lib/helpers'
 
 interface RegisterUserResponse {
   data: User

--- a/lib/api/Bans.ts
+++ b/lib/api/Bans.ts
@@ -25,11 +25,11 @@ export class Bans<
    *
    * @tags Bans
    * @name BansLeaderboardDetail
-   * @summary Get bans by leaderboard ID
+   * @summary Gets all Bans associated with a Leaderboard ID.
    * @request GET:/api/Bans/leaderboard/{leaderboardId}
-   * @response `200` `(Ban)[]` A list of bans. Can be an empty array.
+   * @response `200` `(Ban)[]` The list of `Ban`s was retrieved successfully. The result can be an empty collection.
    * @response `400` `ProblemDetails` Bad Request
-   * @response `404` `ProblemDetails` No bans found for the Leaderboard.
+   * @response `404` `ProblemDetails` No `Leaderboard` with the requested ID could be found.
    */
   bansLeaderboardDetail = (leaderboardId: number, params: RequestParams = {}) =>
     this.request<Ban[], ProblemDetails>({
@@ -43,13 +43,13 @@ export class Bans<
    *
    * @tags Bans
    * @name BansLeaderboardDetail2
-   * @summary Get bans by user ID.
+   * @summary Gets all Bans associated with a User ID.
    * @request GET:/api/Bans/leaderboard/{bannedUserId}
    * @originalName bansLeaderboardDetail
    * @duplicate
-   * @response `200` `(Ban)[]` A list of bans. Can be an empty array.
+   * @response `200` `(Ban)[]` The list of `Ban`s was retrieved successfully. The result can be an empty collection.
    * @response `400` `ProblemDetails` Bad Request
-   * @response `404` `ProblemDetails` No bans found for the User.
+   * @response `404` `ProblemDetails` No `User` with the requested ID could be found.
    */
   bansLeaderboardDetail2 = (bannedUserId: string, params: RequestParams = {}) =>
     this.request<Ban[], ProblemDetails>({
@@ -63,11 +63,13 @@ export class Bans<
    *
    * @tags Bans
    * @name BansDetail
-   * @summary Get a Ban from its ID.
+   * @summary Gets a Ban by its ID.
    * @request GET:/api/Bans/{id}
-   * @response `200` `Ban` The found Ban.
+   * @response `200` `Ban` The `Ban` was found and returned successfully.
    * @response `400` `ProblemDetails` Bad Request
-   * @response `404` `ProblemDetails` If no Ban can be found.
+   * @response `401` `ProblemDetails` Unauthorized
+   * @response `403` `ProblemDetails` Forbidden
+   * @response `404` `ProblemDetails` No `Ban` with the requested ID could be found.
    */
   bansDetail = (id: number, params: RequestParams = {}) =>
     this.request<Ban, ProblemDetails>({
@@ -77,18 +79,39 @@ export class Bans<
       ...params,
     })
   /**
-   * No description
-   *
-   * @tags Bans
-   * @name BansCreate
-   * @summary Creates a side-wide ban. Admin-only.
-   * @request POST:/api/Bans
-   * @response `201` `Ban` The created Ban.
-   * @response `400` `ProblemDetails` If the request is malformed.
-   * @response `401` `ProblemDetails` If a non-admin calls this.
-   * @response `403` `ProblemDetails` If the banned user is also an admin.
-   * @response `404` `ProblemDetails` If the banned user is not found.
-   */
+ * No description
+ *
+ * @tags Bans
+ * @name BansDelete
+ * @summary Lifts a Leaderboard-scoped or site-scoped Ban.
+This request is restricted to Administrators.
+ * @request DELETE:/api/Bans/{id}
+ * @response `204` `void` The `Ban` was removed successfully.
+ * @response `400` `ProblemDetails` Bad Request
+ * @response `401` `ProblemDetails` The requesting `User` is not logged-in.
+ * @response `403` `ProblemDetails` The requesting `User` is unauthorized to lift `Ban`s.
+ * @response `404` `ProblemDetails` No `Ban` with the requested ID could be found.
+ */
+  bansDelete = (id: number, params: RequestParams = {}) =>
+    this.request<void, ProblemDetails>({
+      path: `/api/Bans/${id}`,
+      method: 'DELETE',
+      ...params,
+    })
+  /**
+ * No description
+ *
+ * @tags Bans
+ * @name BansCreate
+ * @summary Issues a site-scoped Ban.
+This request is restricted to Administrators.
+ * @request POST:/api/Bans
+ * @response `201` `Ban` The `Ban` was created and returned successfully.
+ * @response `400` `ProblemDetails` The request was malformed.
+ * @response `401` `ProblemDetails` The requesting `User` is unauthorized to issue site-scoped `Ban`s.
+ * @response `403` `ProblemDetails` The `User` to be banned was also an Administrator. This operation is forbidden.
+ * @response `404` `ProblemDetails` The `User` to be banned was not found.
+ */
   bansCreate = (data: CreateSiteBanRequest, params: RequestParams = {}) =>
     this.request<Ban, ProblemDetails>({
       path: `/api/Bans`,
@@ -99,18 +122,19 @@ export class Bans<
       ...params,
     })
   /**
-   * No description
-   *
-   * @tags Bans
-   * @name BansLeaderboardCreate
-   * @summary Creates a leaderboard-wide ban. Mod-only.
-   * @request POST:/api/Bans/leaderboard
-   * @response `201` `Ban` The created Ban.
-   * @response `400` `ProblemDetails` If the request is malformed.
-   * @response `401` `ProblemDetails` If a non-admin or mod calls this.
-   * @response `403` `ProblemDetails` If the banned user is an admin or a mod.
-   * @response `404` `ProblemDetails` If the banned user is not found.
-   */
+ * No description
+ *
+ * @tags Bans
+ * @name BansLeaderboardCreate
+ * @summary Issues a Leaderboard-scoped Ban.
+This request is restricted to Moderators and Administrators.
+ * @request POST:/api/Bans/leaderboard
+ * @response `201` `Ban` The `Ban` was created and returned successfully.
+ * @response `400` `ProblemDetails` The request was malformed.
+ * @response `401` `ProblemDetails` The requesting `User` is unauthorized to issue `Leaderboard`-scoped `Ban`s.
+ * @response `403` `ProblemDetails` The `User` to be banned was also an Administrator. This operation is forbidden.
+ * @response `404` `ProblemDetails` The `User` to be banned was not found.
+ */
   bansLeaderboardCreate = (
     data: CreateLeaderboardBanRequest,
     params: RequestParams = {},
@@ -121,6 +145,30 @@ export class Bans<
       body: data,
       type: ContentType.Json,
       format: 'json',
+      ...params,
+    })
+  /**
+ * No description
+ *
+ * @tags Bans
+ * @name BansLeaderboardsDelete
+ * @summary Lift a Leaderboard-scoped Ban.
+This request is restricted to Moderators and Administrators.
+ * @request DELETE:/api/Bans/{id}/leaderboards/{leaderboardId}
+ * @response `204` `void` The `Ban` was removed successfully.
+ * @response `400` `ProblemDetails` Bad Request
+ * @response `401` `ProblemDetails` The requesting `User` is not logged-in.
+ * @response `403` `ProblemDetails` The requesting `User` is unauthorized to lift `Ban`s.
+ * @response `404` `ProblemDetails` No `Ban` with the requested ID could be found.
+ */
+  bansLeaderboardsDelete = (
+    id: number,
+    leaderboardId: number,
+    params: RequestParams = {},
+  ) =>
+    this.request<void, ProblemDetails>({
+      path: `/api/Bans/${id}/leaderboards/${leaderboardId}`,
+      method: 'DELETE',
       ...params,
     })
 }

--- a/lib/api/BansRoute.ts
+++ b/lib/api/BansRoute.ts
@@ -20,14 +20,20 @@ export namespace Bans {
    * No description
    * @tags Bans
    * @name BansLeaderboardDetail
-   * @summary Get bans by leaderboard ID
+   * @summary Gets all Bans associated with a Leaderboard ID.
    * @request GET:/api/Bans/leaderboard/{leaderboardId}
-   * @response `200` `(Ban)[]` A list of bans. Can be an empty array.
+   * @response `200` `(Ban)[]` The list of `Ban`s was retrieved successfully. The result can be an empty collection.
    * @response `400` `ProblemDetails` Bad Request
-   * @response `404` `ProblemDetails` No bans found for the Leaderboard.
+   * @response `404` `ProblemDetails` No `Leaderboard` with the requested ID could be found.
    */
   export namespace BansLeaderboardDetail {
-    export type RequestParams = { leaderboardId: number }
+    export type RequestParams = {
+      /**
+       * The ID of the `Leaderboard` whose `Ban`s should be listed.
+       * @format int64
+       */
+      leaderboardId: number
+    }
     export type RequestQuery = {}
     export type RequestBody = never
     export type RequestHeaders = {}
@@ -38,16 +44,22 @@ export namespace Bans {
    * No description
    * @tags Bans
    * @name BansLeaderboardDetail2
-   * @summary Get bans by user ID.
+   * @summary Gets all Bans associated with a User ID.
    * @request GET:/api/Bans/leaderboard/{bannedUserId}
    * @originalName bansLeaderboardDetail
    * @duplicate
-   * @response `200` `(Ban)[]` A list of bans. Can be an empty array.
+   * @response `200` `(Ban)[]` The list of `Ban`s was retrieved successfully. The result can be an empty collection.
    * @response `400` `ProblemDetails` Bad Request
-   * @response `404` `ProblemDetails` No bans found for the User.
+   * @response `404` `ProblemDetails` No `User` with the requested ID could be found.
    */
   export namespace BansLeaderboardDetail2 {
-    export type RequestParams = { bannedUserId: string }
+    export type RequestParams = {
+      /**
+       * The ID of the `User` whose `Ban`s should be listed.
+       * @format uuid
+       */
+      bannedUserId: string
+    }
     export type RequestQuery = {}
     export type RequestBody = never
     export type RequestHeaders = {}
@@ -58,14 +70,22 @@ export namespace Bans {
    * No description
    * @tags Bans
    * @name BansDetail
-   * @summary Get a Ban from its ID.
+   * @summary Gets a Ban by its ID.
    * @request GET:/api/Bans/{id}
-   * @response `200` `Ban` The found Ban.
+   * @response `200` `Ban` The `Ban` was found and returned successfully.
    * @response `400` `ProblemDetails` Bad Request
-   * @response `404` `ProblemDetails` If no Ban can be found.
+   * @response `401` `ProblemDetails` Unauthorized
+   * @response `403` `ProblemDetails` Forbidden
+   * @response `404` `ProblemDetails` No `Ban` with the requested ID could be found.
    */
   export namespace BansDetail {
-    export type RequestParams = { id: number }
+    export type RequestParams = {
+      /**
+       * The ID of the `Ban` which should be retrieved.
+       * @format int64
+       */
+      id: number
+    }
     export type RequestQuery = {}
     export type RequestBody = never
     export type RequestHeaders = {}
@@ -73,17 +93,45 @@ export namespace Bans {
   }
 
   /**
-   * No description
-   * @tags Bans
-   * @name BansCreate
-   * @summary Creates a side-wide ban. Admin-only.
-   * @request POST:/api/Bans
-   * @response `201` `Ban` The created Ban.
-   * @response `400` `ProblemDetails` If the request is malformed.
-   * @response `401` `ProblemDetails` If a non-admin calls this.
-   * @response `403` `ProblemDetails` If the banned user is also an admin.
-   * @response `404` `ProblemDetails` If the banned user is not found.
-   */
+ * No description
+ * @tags Bans
+ * @name BansDelete
+ * @summary Lifts a Leaderboard-scoped or site-scoped Ban.
+This request is restricted to Administrators.
+ * @request DELETE:/api/Bans/{id}
+ * @response `204` `void` The `Ban` was removed successfully.
+ * @response `400` `ProblemDetails` Bad Request
+ * @response `401` `ProblemDetails` The requesting `User` is not logged-in.
+ * @response `403` `ProblemDetails` The requesting `User` is unauthorized to lift `Ban`s.
+ * @response `404` `ProblemDetails` No `Ban` with the requested ID could be found.
+*/
+  export namespace BansDelete {
+    export type RequestParams = {
+      /**
+       * The ID of the `Ban` to remove.
+       * @format int64
+       */
+      id: number
+    }
+    export type RequestQuery = {}
+    export type RequestBody = never
+    export type RequestHeaders = {}
+    export type ResponseBody = void
+  }
+
+  /**
+ * No description
+ * @tags Bans
+ * @name BansCreate
+ * @summary Issues a site-scoped Ban.
+This request is restricted to Administrators.
+ * @request POST:/api/Bans
+ * @response `201` `Ban` The `Ban` was created and returned successfully.
+ * @response `400` `ProblemDetails` The request was malformed.
+ * @response `401` `ProblemDetails` The requesting `User` is unauthorized to issue site-scoped `Ban`s.
+ * @response `403` `ProblemDetails` The `User` to be banned was also an Administrator. This operation is forbidden.
+ * @response `404` `ProblemDetails` The `User` to be banned was not found.
+*/
   export namespace BansCreate {
     export type RequestParams = {}
     export type RequestQuery = {}
@@ -93,22 +141,55 @@ export namespace Bans {
   }
 
   /**
-   * No description
-   * @tags Bans
-   * @name BansLeaderboardCreate
-   * @summary Creates a leaderboard-wide ban. Mod-only.
-   * @request POST:/api/Bans/leaderboard
-   * @response `201` `Ban` The created Ban.
-   * @response `400` `ProblemDetails` If the request is malformed.
-   * @response `401` `ProblemDetails` If a non-admin or mod calls this.
-   * @response `403` `ProblemDetails` If the banned user is an admin or a mod.
-   * @response `404` `ProblemDetails` If the banned user is not found.
-   */
+ * No description
+ * @tags Bans
+ * @name BansLeaderboardCreate
+ * @summary Issues a Leaderboard-scoped Ban.
+This request is restricted to Moderators and Administrators.
+ * @request POST:/api/Bans/leaderboard
+ * @response `201` `Ban` The `Ban` was created and returned successfully.
+ * @response `400` `ProblemDetails` The request was malformed.
+ * @response `401` `ProblemDetails` The requesting `User` is unauthorized to issue `Leaderboard`-scoped `Ban`s.
+ * @response `403` `ProblemDetails` The `User` to be banned was also an Administrator. This operation is forbidden.
+ * @response `404` `ProblemDetails` The `User` to be banned was not found.
+*/
   export namespace BansLeaderboardCreate {
     export type RequestParams = {}
     export type RequestQuery = {}
     export type RequestBody = CreateLeaderboardBanRequest
     export type RequestHeaders = {}
     export type ResponseBody = Ban
+  }
+
+  /**
+ * No description
+ * @tags Bans
+ * @name BansLeaderboardsDelete
+ * @summary Lift a Leaderboard-scoped Ban.
+This request is restricted to Moderators and Administrators.
+ * @request DELETE:/api/Bans/{id}/leaderboards/{leaderboardId}
+ * @response `204` `void` The `Ban` was removed successfully.
+ * @response `400` `ProblemDetails` Bad Request
+ * @response `401` `ProblemDetails` The requesting `User` is not logged-in.
+ * @response `403` `ProblemDetails` The requesting `User` is unauthorized to lift `Ban`s.
+ * @response `404` `ProblemDetails` No `Ban` with the requested ID could be found.
+*/
+  export namespace BansLeaderboardsDelete {
+    export type RequestParams = {
+      /**
+       * The ID of the `Ban` to remove.
+       * @format int64
+       */
+      id: number
+      /**
+       * The ID of the `Leaderboard` the `Ban` is scoped to.
+       * @format int64
+       */
+      leaderboardId: number
+    }
+    export type RequestQuery = {}
+    export type RequestBody = never
+    export type RequestHeaders = {}
+    export type ResponseBody = void
   }
 }

--- a/lib/api/Categories.ts
+++ b/lib/api/Categories.ts
@@ -24,11 +24,13 @@ export class Categories<
    *
    * @tags Categories
    * @name CategoriesDetail
-   * @summary Gets a Category from its ID.
+   * @summary Gets a Category by its ID.
    * @request GET:/api/Categories/{id}
-   * @response `200` `Category` The Category with the provided ID.
+   * @response `200` `Category` The `Category` was found and returned successfully.
    * @response `400` `ProblemDetails` Bad Request
-   * @response `404` `ProblemDetails` If no Category can be found.
+   * @response `401` `ProblemDetails` Unauthorized
+   * @response `403` `ProblemDetails` Forbidden
+   * @response `404` `ProblemDetails` No `Category` with the requested ID could be found.
    */
   categoriesDetail = (id: number, params: RequestParams = {}) =>
     this.request<Category, ProblemDetails>({
@@ -38,16 +40,19 @@ export class Categories<
       ...params,
     })
   /**
-   * No description
-   *
-   * @tags Categories
-   * @name CategoriesCreate
-   * @summary Creates a new Category. Mod-only.
-   * @request POST:/api/Categories
-   * @response `201` `Category` The created Category.
-   * @response `400` `ProblemDetails` If the request is malformed.
-   * @response `404` `ProblemDetails` If a non-mod calls this.
-   */
+ * No description
+ *
+ * @tags Categories
+ * @name CategoriesCreate
+ * @summary Creates a new Category.
+This request is restricted to Moderators.
+ * @request POST:/api/Categories
+ * @response `201` `Category` The `Category` was created and returned successfully.
+ * @response `400` `ProblemDetails` The request was malformed.
+ * @response `401` `ProblemDetails` Unauthorized
+ * @response `403` `ProblemDetails` Forbidden
+ * @response `404` `ProblemDetails` The requesting `User` is unauthorized to create a `Category`.
+ */
   categoriesCreate = (
     data: CreateCategoryRequest,
     params: RequestParams = {},

--- a/lib/api/CategoriesRoute.ts
+++ b/lib/api/CategoriesRoute.ts
@@ -16,14 +16,22 @@ export namespace Categories {
    * No description
    * @tags Categories
    * @name CategoriesDetail
-   * @summary Gets a Category from its ID.
+   * @summary Gets a Category by its ID.
    * @request GET:/api/Categories/{id}
-   * @response `200` `Category` The Category with the provided ID.
+   * @response `200` `Category` The `Category` was found and returned successfully.
    * @response `400` `ProblemDetails` Bad Request
-   * @response `404` `ProblemDetails` If no Category can be found.
+   * @response `401` `ProblemDetails` Unauthorized
+   * @response `403` `ProblemDetails` Forbidden
+   * @response `404` `ProblemDetails` No `Category` with the requested ID could be found.
    */
   export namespace CategoriesDetail {
-    export type RequestParams = { id: number }
+    export type RequestParams = {
+      /**
+       * The ID of the `Category` which should be retrieved.
+       * @format int64
+       */
+      id: number
+    }
     export type RequestQuery = {}
     export type RequestBody = never
     export type RequestHeaders = {}
@@ -31,15 +39,18 @@ export namespace Categories {
   }
 
   /**
-   * No description
-   * @tags Categories
-   * @name CategoriesCreate
-   * @summary Creates a new Category. Mod-only.
-   * @request POST:/api/Categories
-   * @response `201` `Category` The created Category.
-   * @response `400` `ProblemDetails` If the request is malformed.
-   * @response `404` `ProblemDetails` If a non-mod calls this.
-   */
+ * No description
+ * @tags Categories
+ * @name CategoriesCreate
+ * @summary Creates a new Category.
+This request is restricted to Moderators.
+ * @request POST:/api/Categories
+ * @response `201` `Category` The `Category` was created and returned successfully.
+ * @response `400` `ProblemDetails` The request was malformed.
+ * @response `401` `ProblemDetails` Unauthorized
+ * @response `403` `ProblemDetails` Forbidden
+ * @response `404` `ProblemDetails` The requesting `User` is unauthorized to create a `Category`.
+*/
   export namespace CategoriesCreate {
     export type RequestParams = {}
     export type RequestQuery = {}

--- a/lib/api/Judgements.ts
+++ b/lib/api/Judgements.ts
@@ -24,11 +24,11 @@ export class Judgements<
    *
    * @tags Judgements
    * @name JudgementsDetail
-   * @summary Gets a Judgement from its ID.
+   * @summary Gets a Judgement by its ID.
    * @request GET:/api/Judgements/{id}
-   * @response `200` `JudgementViewModel` The Judgement with the provided ID.
+   * @response `200` `JudgementViewModel` The `Judgement` was found and returned successfully.
    * @response `400` `ProblemDetails` Bad Request
-   * @response `404` `ProblemDetails` If no Judgement can be found.
+   * @response `404` `ProblemDetails` No `Judgement` with the requested ID could be found.
    */
   judgementsDetail = (id: number, params: RequestParams = {}) =>
     this.request<JudgementViewModel, ProblemDetails>({
@@ -38,16 +38,19 @@ export class Judgements<
       ...params,
     })
   /**
-   * No description
-   *
-   * @tags Judgements
-   * @name JudgementsCreate
-   * @summary Creates a judgement for a run.
-   * @request POST:/api/Judgements
-   * @response `201` `JudgementViewModel` The created judgement.
-   * @response `400` `ProblemDetails` The request body is malformed.
-   * @response `404` `ProblemDetails` For an invalid judgement.
-   */
+ * No description
+ *
+ * @tags Judgements
+ * @name JudgementsCreate
+ * @summary Creates a new Judgement for a Run.
+This request is restricted to Moderators.
+ * @request POST:/api/Judgements
+ * @response `201` `JudgementViewModel` The `Judgement` was created and returned successfully.
+ * @response `400` `ProblemDetails` The request was malformed.
+ * @response `401` `ProblemDetails` Unauthorized
+ * @response `403` `ProblemDetails` The requesting `User` is unauthorized to create `Judgement`s.
+ * @response `404` `ProblemDetails` No `Run` with the ID from the request could be found.
+ */
   judgementsCreate = (
     data: CreateJudgementRequest,
     params: RequestParams = {},

--- a/lib/api/JudgementsRoute.ts
+++ b/lib/api/JudgementsRoute.ts
@@ -16,14 +16,20 @@ export namespace Judgements {
    * No description
    * @tags Judgements
    * @name JudgementsDetail
-   * @summary Gets a Judgement from its ID.
+   * @summary Gets a Judgement by its ID.
    * @request GET:/api/Judgements/{id}
-   * @response `200` `JudgementViewModel` The Judgement with the provided ID.
+   * @response `200` `JudgementViewModel` The `Judgement` was found and returned successfully.
    * @response `400` `ProblemDetails` Bad Request
-   * @response `404` `ProblemDetails` If no Judgement can be found.
+   * @response `404` `ProblemDetails` No `Judgement` with the requested ID could be found.
    */
   export namespace JudgementsDetail {
-    export type RequestParams = { id: number }
+    export type RequestParams = {
+      /**
+       * The ID of the `Judgement` which should be retrieved.
+       * @format int64
+       */
+      id: number
+    }
     export type RequestQuery = {}
     export type RequestBody = never
     export type RequestHeaders = {}
@@ -31,15 +37,18 @@ export namespace Judgements {
   }
 
   /**
-   * No description
-   * @tags Judgements
-   * @name JudgementsCreate
-   * @summary Creates a judgement for a run.
-   * @request POST:/api/Judgements
-   * @response `201` `JudgementViewModel` The created judgement.
-   * @response `400` `ProblemDetails` The request body is malformed.
-   * @response `404` `ProblemDetails` For an invalid judgement.
-   */
+ * No description
+ * @tags Judgements
+ * @name JudgementsCreate
+ * @summary Creates a new Judgement for a Run.
+This request is restricted to Moderators.
+ * @request POST:/api/Judgements
+ * @response `201` `JudgementViewModel` The `Judgement` was created and returned successfully.
+ * @response `400` `ProblemDetails` The request was malformed.
+ * @response `401` `ProblemDetails` Unauthorized
+ * @response `403` `ProblemDetails` The requesting `User` is unauthorized to create `Judgement`s.
+ * @response `404` `ProblemDetails` No `Run` with the ID from the request could be found.
+*/
   export namespace JudgementsCreate {
     export type RequestParams = {}
     export type RequestQuery = {}

--- a/lib/api/Leaderboards.ts
+++ b/lib/api/Leaderboards.ts
@@ -25,11 +25,11 @@ export class Leaderboards<
    *
    * @tags Leaderboards
    * @name LeaderboardsDetail
-   * @summary Gets a leaderboard.
+   * @summary Gets a Leaderboard by its ID.
    * @request GET:/api/Leaderboards/{id}
-   * @response `200` `Leaderboard` The Leaderboard.
+   * @response `200` `Leaderboard` The `Leaderboard` was found and returned successfully.
    * @response `400` `ProblemDetails` Bad Request
-   * @response `404` `ProblemDetails` If no Leaderboard can be found.
+   * @response `404` `ProblemDetails` No `Leaderboard` with the requested ID could be found.
    */
   leaderboardsDetail = (id: number, params: RequestParams = {}) =>
     this.request<Leaderboard, ProblemDetails>({
@@ -43,9 +43,9 @@ export class Leaderboards<
    *
    * @tags Leaderboards
    * @name LeaderboardsList
-   * @summary Gets leaderboards. Can be an empty array.
+   * @summary Gets Leaderboards by their IDs.
    * @request GET:/api/Leaderboards
-   * @response `200` `(Leaderboard)[]` An array of Leaderboards. Can be empty.
+   * @response `200` `(Leaderboard)[]` The list of `Leaderboard`s was retrieved successfully. The result can be an empty collection.
    */
   leaderboardsList = (
     query: LeaderboardsListParams,
@@ -59,16 +59,19 @@ export class Leaderboards<
       ...params,
     })
   /**
-   * No description
-   *
-   * @tags Leaderboards
-   * @name LeaderboardsCreate
-   * @summary Creates a new Leaderboard. Admin-only.
-   * @request POST:/api/Leaderboards
-   * @response `201` `Leaderboard` The created Leaderboard.
-   * @response `400` `ProblemDetails` If the request is malformed.
-   * @response `404` `ProblemDetails` If a non-admin calls this.
-   */
+ * No description
+ *
+ * @tags Leaderboards
+ * @name LeaderboardsCreate
+ * @summary Creates a new Leaderboard.
+This request is restricted to Administrators.
+ * @request POST:/api/Leaderboards
+ * @response `201` `Leaderboard` The `Leaderboard` was created and returned successfully.
+ * @response `400` `ProblemDetails` The request was malformed.
+ * @response `401` `ProblemDetails` Unauthorized
+ * @response `403` `ProblemDetails` Forbidden
+ * @response `404` `ProblemDetails` The requesting `User` is unauthorized to create `Leaderboard`s.
+ */
   leaderboardsCreate = (
     data: CreateLeaderboardRequest,
     params: RequestParams = {},

--- a/lib/api/LeaderboardsRoute.ts
+++ b/lib/api/LeaderboardsRoute.ts
@@ -16,14 +16,20 @@ export namespace Leaderboards {
    * No description
    * @tags Leaderboards
    * @name LeaderboardsDetail
-   * @summary Gets a leaderboard.
+   * @summary Gets a Leaderboard by its ID.
    * @request GET:/api/Leaderboards/{id}
-   * @response `200` `Leaderboard` The Leaderboard.
+   * @response `200` `Leaderboard` The `Leaderboard` was found and returned successfully.
    * @response `400` `ProblemDetails` Bad Request
-   * @response `404` `ProblemDetails` If no Leaderboard can be found.
+   * @response `404` `ProblemDetails` No `Leaderboard` with the requested ID could be found.
    */
   export namespace LeaderboardsDetail {
-    export type RequestParams = { id: number }
+    export type RequestParams = {
+      /**
+       * The ID of the `Leaderboard` which should be retrieved.
+       * @format int64
+       */
+      id: number
+    }
     export type RequestQuery = {}
     export type RequestBody = never
     export type RequestHeaders = {}
@@ -34,28 +40,34 @@ export namespace Leaderboards {
    * No description
    * @tags Leaderboards
    * @name LeaderboardsList
-   * @summary Gets leaderboards. Can be an empty array.
+   * @summary Gets Leaderboards by their IDs.
    * @request GET:/api/Leaderboards
-   * @response `200` `(Leaderboard)[]` An array of Leaderboards. Can be empty.
+   * @response `200` `(Leaderboard)[]` The list of `Leaderboard`s was retrieved successfully. The result can be an empty collection.
    */
   export namespace LeaderboardsList {
     export type RequestParams = {}
-    export type RequestQuery = { ids?: number[] }
+    export type RequestQuery = {
+      /** The IDs of the `Leaderboard`s which should be retrieved. */
+      ids?: number[]
+    }
     export type RequestBody = never
     export type RequestHeaders = {}
     export type ResponseBody = Leaderboard[]
   }
 
   /**
-   * No description
-   * @tags Leaderboards
-   * @name LeaderboardsCreate
-   * @summary Creates a new Leaderboard. Admin-only.
-   * @request POST:/api/Leaderboards
-   * @response `201` `Leaderboard` The created Leaderboard.
-   * @response `400` `ProblemDetails` If the request is malformed.
-   * @response `404` `ProblemDetails` If a non-admin calls this.
-   */
+ * No description
+ * @tags Leaderboards
+ * @name LeaderboardsCreate
+ * @summary Creates a new Leaderboard.
+This request is restricted to Administrators.
+ * @request POST:/api/Leaderboards
+ * @response `201` `Leaderboard` The `Leaderboard` was created and returned successfully.
+ * @response `400` `ProblemDetails` The request was malformed.
+ * @response `401` `ProblemDetails` Unauthorized
+ * @response `403` `ProblemDetails` Forbidden
+ * @response `404` `ProblemDetails` The requesting `User` is unauthorized to create `Leaderboard`s.
+*/
   export namespace LeaderboardsCreate {
     export type RequestParams = {}
     export type RequestQuery = {}

--- a/lib/api/Modships.ts
+++ b/lib/api/Modships.ts
@@ -25,11 +25,13 @@ export class Modships<
    *
    * @tags Modships
    * @name ModshipsDetail
-   * @summary Gets a Modship.
+   * @summary Gets a Modship by its ID.
    * @request GET:/api/Modships/{id}
-   * @response `200` `Modship` The Modship.
+   * @response `200` `Modship` The `Modship` was found and returned successfully.
    * @response `400` `ProblemDetails` Bad Request
-   * @response `404` `ProblemDetails` If no Modship can be found.
+   * @response `401` `ProblemDetails` Unauthorized
+   * @response `403` `ProblemDetails` Forbidden
+   * @response `404` `ProblemDetails` No `User` with the requested ID could be found.
    */
   modshipsDetail = (id: string, params: RequestParams = {}) =>
     this.request<Modship, ProblemDetails>({
@@ -39,16 +41,19 @@ export class Modships<
       ...params,
     })
   /**
-   * No description
-   *
-   * @tags Modships
-   * @name ModshipsCreate
-   * @summary Makes a User a Mod for a Leaderboard. Admin-only.
-   * @request POST:/api/Modships
-   * @response `201` `void` An object containing the Modship ID.
-   * @response `400` `ProblemDetails` If the request is malformed.
-   * @response `404` `ProblemDetails` If a non-admin calls this.
-   */
+ * No description
+ *
+ * @tags Modships
+ * @name ModshipsCreate
+ * @summary Promotes a User to Moderator for a Leaderboard.
+This request is restricted to Administrators.
+ * @request POST:/api/Modships
+ * @response `201` `void` The `User` was promoted successfully. The `Modship` is returned.
+ * @response `400` `ProblemDetails` The request was malformed.
+ * @response `401` `ProblemDetails` Unauthorized
+ * @response `403` `ProblemDetails` Forbidden
+ * @response `404` `ProblemDetails` The requesting `User` is unauthorized to promote other `User`s.
+ */
   modshipsCreate = (data: CreateModshipRequest, params: RequestParams = {}) =>
     this.request<void, ProblemDetails>({
       path: `/api/Modships`,
@@ -58,16 +63,19 @@ export class Modships<
       ...params,
     })
   /**
-   * No description
-   *
-   * @tags Modships
-   * @name ModshipsDelete
-   * @summary Removes a User as a Mod from a Leaderboard. Admin-only.
-   * @request DELETE:/api/Modships
-   * @response `204` `void` Request was successfull.
-   * @response `400` `ProblemDetails` If the request is malformed.
-   * @response `404` `ProblemDetails` The User, Leaderboard or Modship was not found.
-   */
+ * No description
+ *
+ * @tags Modships
+ * @name ModshipsDelete
+ * @summary Demotes a Moderator to User for a Leaderboard.
+This request is restricted to Administrators.
+ * @request DELETE:/api/Modships
+ * @response `204` `void` The `User` was demoted successfully.
+ * @response `400` `ProblemDetails` The request was malformed.
+ * @response `401` `ProblemDetails` Unauthorized
+ * @response `403` `ProblemDetails` Forbidden
+ * @response `404` `ProblemDetails` No `User`, `Leaderboard`, or `Modship` with the requested IDs could be found, or the requesting `User` is unauthorized to demote other `User`s.
+ */
   modshipsDelete = (data: RemoveModshipRequest, params: RequestParams = {}) =>
     this.request<void, ProblemDetails>({
       path: `/api/Modships`,

--- a/lib/api/ModshipsRoute.ts
+++ b/lib/api/ModshipsRoute.ts
@@ -20,14 +20,22 @@ export namespace Modships {
    * No description
    * @tags Modships
    * @name ModshipsDetail
-   * @summary Gets a Modship.
+   * @summary Gets a Modship by its ID.
    * @request GET:/api/Modships/{id}
-   * @response `200` `Modship` The Modship.
+   * @response `200` `Modship` The `Modship` was found and returned successfully.
    * @response `400` `ProblemDetails` Bad Request
-   * @response `404` `ProblemDetails` If no Modship can be found.
+   * @response `401` `ProblemDetails` Unauthorized
+   * @response `403` `ProblemDetails` Forbidden
+   * @response `404` `ProblemDetails` No `User` with the requested ID could be found.
    */
   export namespace ModshipsDetail {
-    export type RequestParams = { id: string }
+    export type RequestParams = {
+      /**
+       * The ID of the *Moderator* (`User`) which should be retrieved.
+       * @format uuid
+       */
+      id: string
+    }
     export type RequestQuery = {}
     export type RequestBody = never
     export type RequestHeaders = {}
@@ -35,15 +43,18 @@ export namespace Modships {
   }
 
   /**
-   * No description
-   * @tags Modships
-   * @name ModshipsCreate
-   * @summary Makes a User a Mod for a Leaderboard. Admin-only.
-   * @request POST:/api/Modships
-   * @response `201` `void` An object containing the Modship ID.
-   * @response `400` `ProblemDetails` If the request is malformed.
-   * @response `404` `ProblemDetails` If a non-admin calls this.
-   */
+ * No description
+ * @tags Modships
+ * @name ModshipsCreate
+ * @summary Promotes a User to Moderator for a Leaderboard.
+This request is restricted to Administrators.
+ * @request POST:/api/Modships
+ * @response `201` `void` The `User` was promoted successfully. The `Modship` is returned.
+ * @response `400` `ProblemDetails` The request was malformed.
+ * @response `401` `ProblemDetails` Unauthorized
+ * @response `403` `ProblemDetails` Forbidden
+ * @response `404` `ProblemDetails` The requesting `User` is unauthorized to promote other `User`s.
+*/
   export namespace ModshipsCreate {
     export type RequestParams = {}
     export type RequestQuery = {}
@@ -53,15 +64,18 @@ export namespace Modships {
   }
 
   /**
-   * No description
-   * @tags Modships
-   * @name ModshipsDelete
-   * @summary Removes a User as a Mod from a Leaderboard. Admin-only.
-   * @request DELETE:/api/Modships
-   * @response `204` `void` Request was successfull.
-   * @response `400` `ProblemDetails` If the request is malformed.
-   * @response `404` `ProblemDetails` The User, Leaderboard or Modship was not found.
-   */
+ * No description
+ * @tags Modships
+ * @name ModshipsDelete
+ * @summary Demotes a Moderator to User for a Leaderboard.
+This request is restricted to Administrators.
+ * @request DELETE:/api/Modships
+ * @response `204` `void` The `User` was demoted successfully.
+ * @response `400` `ProblemDetails` The request was malformed.
+ * @response `401` `ProblemDetails` Unauthorized
+ * @response `403` `ProblemDetails` Forbidden
+ * @response `404` `ProblemDetails` No `User`, `Leaderboard`, or `Modship` with the requested IDs could be found, or the requesting `User` is unauthorized to demote other `User`s.
+*/
   export namespace ModshipsDelete {
     export type RequestParams = {}
     export type RequestQuery = {}

--- a/lib/api/Participations.ts
+++ b/lib/api/Participations.ts
@@ -25,10 +25,11 @@ export class Participations<
    *
    * @tags Participations
    * @name ParticipationsDetail
+   * @summary Gets a Participation by its ID.
    * @request GET:/api/Participations/{id}
-   * @response `200` `Participation` Success
+   * @response `200` `Participation` The `Participation` was found and returned successfully.
    * @response `400` `ProblemDetails` Bad Request
-   * @response `404` `ProblemDetails` Not Found
+   * @response `404` `ProblemDetails` No `Participation` with the requested ID could be found.
    */
   participationsDetail = (id: number, params: RequestParams = {}) =>
     this.request<Participation, ProblemDetails>({
@@ -42,10 +43,13 @@ export class Participations<
    *
    * @tags Participations
    * @name ParticipationsCreate
+   * @summary Creates a Participation for a User.
    * @request POST:/api/Participations
-   * @response `201` `void` Success
+   * @response `201` `void` The `Participation` was created and returned successfully.
    * @response `400` `ProblemDetails` Bad Request
-   * @response `404` `ProblemDetails` Not Found
+   * @response `401` `ProblemDetails` Unauthorized
+   * @response `403` `ProblemDetails` Forbidden
+   * @response `404` `ProblemDetails` No `User` or `Run` with the requested IDs could be found.
    */
   participationsCreate = (
     data: CreateParticipationRequest,
@@ -59,15 +63,16 @@ export class Participations<
       ...params,
     })
   /**
-   * No description
+   * @description A comment and VOD link must be provided.
    *
    * @tags Participations
    * @name ParticipationsUpdate
+   * @summary Updates the Participation of a User for a Run.
    * @request PUT:/api/Participations
-   * @response `200` `void` Success
+   * @response `200` `void` The `Participation` was updated successfully.
    * @response `400` `ProblemDetails` Bad Request
    * @response `403` `ProblemDetails` Forbidden
-   * @response `404` `ProblemDetails` Not Found
+   * @response `404` `ProblemDetails` No `Participation` with the requested ID could be found.
    */
   participationsUpdate = (
     data: UpdateParticipationRequest,

--- a/lib/api/ParticipationsRoute.ts
+++ b/lib/api/ParticipationsRoute.ts
@@ -20,13 +20,20 @@ export namespace Participations {
    * No description
    * @tags Participations
    * @name ParticipationsDetail
+   * @summary Gets a Participation by its ID.
    * @request GET:/api/Participations/{id}
-   * @response `200` `Participation` Success
+   * @response `200` `Participation` The `Participation` was found and returned successfully.
    * @response `400` `ProblemDetails` Bad Request
-   * @response `404` `ProblemDetails` Not Found
+   * @response `404` `ProblemDetails` No `Participation` with the requested ID could be found.
    */
   export namespace ParticipationsDetail {
-    export type RequestParams = { id: number }
+    export type RequestParams = {
+      /**
+       * The ID of the `Participation` which should be retrieved.
+       * @format int64
+       */
+      id: number
+    }
     export type RequestQuery = {}
     export type RequestBody = never
     export type RequestHeaders = {}
@@ -37,10 +44,13 @@ export namespace Participations {
    * No description
    * @tags Participations
    * @name ParticipationsCreate
+   * @summary Creates a Participation for a User.
    * @request POST:/api/Participations
-   * @response `201` `void` Success
+   * @response `201` `void` The `Participation` was created and returned successfully.
    * @response `400` `ProblemDetails` Bad Request
-   * @response `404` `ProblemDetails` Not Found
+   * @response `401` `ProblemDetails` Unauthorized
+   * @response `403` `ProblemDetails` Forbidden
+   * @response `404` `ProblemDetails` No `User` or `Run` with the requested IDs could be found.
    */
   export namespace ParticipationsCreate {
     export type RequestParams = {}
@@ -51,14 +61,15 @@ export namespace Participations {
   }
 
   /**
-   * No description
+   * @description A comment and VOD link must be provided.
    * @tags Participations
    * @name ParticipationsUpdate
+   * @summary Updates the Participation of a User for a Run.
    * @request PUT:/api/Participations
-   * @response `200` `void` Success
+   * @response `200` `void` The `Participation` was updated successfully.
    * @response `400` `ProblemDetails` Bad Request
    * @response `403` `ProblemDetails` Forbidden
-   * @response `404` `ProblemDetails` Not Found
+   * @response `404` `ProblemDetails` No `Participation` with the requested ID could be found.
    */
   export namespace ParticipationsUpdate {
     export type RequestParams = {}

--- a/lib/api/Runs.ts
+++ b/lib/api/Runs.ts
@@ -10,6 +10,7 @@
  */
 
 import {
+  Category,
   CreateRunRequest,
   Participation,
   ProblemDetails,
@@ -25,11 +26,13 @@ export class Runs<
    *
    * @tags Runs
    * @name RunsDetail
-   * @summary Gets a Run.
+   * @summary Gets a Run by its ID.
    * @request GET:/api/Runs/{id}
-   * @response `200` `Run` The Run with the provided ID.
+   * @response `200` `Run` The `Run` was found and returned successfully.
    * @response `400` `ProblemDetails` Bad Request
-   * @response `404` `ProblemDetails` If no Run is found with the provided ID.
+   * @response `401` `ProblemDetails` Unauthorized
+   * @response `403` `ProblemDetails` Forbidden
+   * @response `404` `ProblemDetails` No `Run` with the requested ID could be found.
    */
   runsDetail = (id: string, params: RequestParams = {}) =>
     this.request<Run, ProblemDetails>({
@@ -43,10 +46,12 @@ export class Runs<
    *
    * @tags Runs
    * @name RunsCreate
-   * @summary Creates a Run.
+   * @summary Creates a new Run.
    * @request POST:/api/Runs
-   * @response `201` `void` Success
+   * @response `201` `void` The `Run` was created and returned successfully.
    * @response `400` `ProblemDetails` Bad Request
+   * @response `401` `ProblemDetails` Unauthorized
+   * @response `403` `ProblemDetails` Forbidden
    * @response `404` `ProblemDetails` Not Found
    */
   runsCreate = (data: CreateRunRequest, params: RequestParams = {}) =>
@@ -62,15 +67,36 @@ export class Runs<
    *
    * @tags Runs
    * @name RunsParticipationsDetail
-   * @summary Gets the participations for a run.
+   * @summary Gets all Participations associated with a Run ID.
    * @request GET:/api/Runs/{id}/participations
-   * @response `200` `(Participation)[]` An array with all participations.
+   * @response `200` `(Participation)[]` The list of `Participation`s was retrieved successfully.
    * @response `400` `ProblemDetails` Bad Request
-   * @response `404` `ProblemDetails` If the run or no participations are found.
+   * @response `401` `ProblemDetails` Unauthorized
+   * @response `403` `ProblemDetails` Forbidden
+   * @response `404` `ProblemDetails` No `Run` with the requested ID could be found or the `Run` does not contain any `Participation`s.
    */
   runsParticipationsDetail = (id: string, params: RequestParams = {}) =>
     this.request<Participation[], ProblemDetails>({
       path: `/api/Runs/${id}/participations`,
+      method: 'GET',
+      format: 'json',
+      ...params,
+    })
+  /**
+   * No description
+   *
+   * @tags Runs
+   * @name RunsCategoryDetail
+   * @request GET:/api/Runs/{id}/category
+   * @response `200` `Category` Success
+   * @response `400` `ProblemDetails` Bad Request
+   * @response `401` `ProblemDetails` Unauthorized
+   * @response `403` `ProblemDetails` Forbidden
+   * @response `404` `ProblemDetails` Not Found
+   */
+  runsCategoryDetail = (id: string, params: RequestParams = {}) =>
+    this.request<Category, ProblemDetails>({
+      path: `/api/Runs/${id}/category`,
       method: 'GET',
       format: 'json',
       ...params,

--- a/lib/api/RunsRoute.ts
+++ b/lib/api/RunsRoute.ts
@@ -9,21 +9,35 @@
  * ---------------------------------------------------------------
  */
 
-import { CreateRunRequest, Participation, Run } from './data-contracts'
+import {
+  Category,
+  CreateRunRequest,
+  Participation,
+  Run,
+} from './data-contracts'
 
 export namespace Runs {
   /**
    * No description
    * @tags Runs
    * @name RunsDetail
-   * @summary Gets a Run.
+   * @summary Gets a Run by its ID.
    * @request GET:/api/Runs/{id}
-   * @response `200` `Run` The Run with the provided ID.
+   * @response `200` `Run` The `Run` was found and returned successfully.
    * @response `400` `ProblemDetails` Bad Request
-   * @response `404` `ProblemDetails` If no Run is found with the provided ID.
+   * @response `401` `ProblemDetails` Unauthorized
+   * @response `403` `ProblemDetails` Forbidden
+   * @response `404` `ProblemDetails` No `Run` with the requested ID could be found.
    */
   export namespace RunsDetail {
-    export type RequestParams = { id: string }
+    export type RequestParams = {
+      /**
+       * The ID of the `Run` which should be retrieved.<br />
+       * It must be possible to parse this to `long` for this request to complete.
+       * @format uuid
+       */
+      id: string
+    }
     export type RequestQuery = {}
     export type RequestBody = never
     export type RequestHeaders = {}
@@ -34,10 +48,12 @@ export namespace Runs {
    * No description
    * @tags Runs
    * @name RunsCreate
-   * @summary Creates a Run.
+   * @summary Creates a new Run.
    * @request POST:/api/Runs
-   * @response `201` `void` Success
+   * @response `201` `void` The `Run` was created and returned successfully.
    * @response `400` `ProblemDetails` Bad Request
+   * @response `401` `ProblemDetails` Unauthorized
+   * @response `403` `ProblemDetails` Forbidden
    * @response `404` `ProblemDetails` Not Found
    */
   export namespace RunsCreate {
@@ -52,17 +68,48 @@ export namespace Runs {
    * No description
    * @tags Runs
    * @name RunsParticipationsDetail
-   * @summary Gets the participations for a run.
+   * @summary Gets all Participations associated with a Run ID.
    * @request GET:/api/Runs/{id}/participations
-   * @response `200` `(Participation)[]` An array with all participations.
+   * @response `200` `(Participation)[]` The list of `Participation`s was retrieved successfully.
    * @response `400` `ProblemDetails` Bad Request
-   * @response `404` `ProblemDetails` If the run or no participations are found.
+   * @response `401` `ProblemDetails` Unauthorized
+   * @response `403` `ProblemDetails` Forbidden
+   * @response `404` `ProblemDetails` No `Run` with the requested ID could be found or the `Run` does not contain any `Participation`s.
    */
   export namespace RunsParticipationsDetail {
-    export type RequestParams = { id: string }
+    export type RequestParams = {
+      /**
+       * The ID of the `Run` whose `Participation`s should be retrieved.<br />
+       * It must be possible to parse this to `long` for this request to complete.
+       * @format uuid
+       */
+      id: string
+    }
     export type RequestQuery = {}
     export type RequestBody = never
     export type RequestHeaders = {}
     export type ResponseBody = Participation[]
+  }
+
+  /**
+   * No description
+   * @tags Runs
+   * @name RunsCategoryDetail
+   * @request GET:/api/Runs/{id}/category
+   * @response `200` `Category` Success
+   * @response `400` `ProblemDetails` Bad Request
+   * @response `401` `ProblemDetails` Unauthorized
+   * @response `403` `ProblemDetails` Forbidden
+   * @response `404` `ProblemDetails` Not Found
+   */
+  export namespace RunsCategoryDetail {
+    export type RequestParams = {
+      /** @format uuid */
+      id: string
+    }
+    export type RequestQuery = {}
+    export type RequestBody = never
+    export type RequestHeaders = {}
+    export type ResponseBody = Category
   }
 }

--- a/lib/api/Users.ts
+++ b/lib/api/Users.ts
@@ -26,11 +26,11 @@ export class Users<
    *
    * @tags Users
    * @name UsersDetail
-   * @summary Gets a User by ID.
+   * @summary Gets a User by their ID.
    * @request GET:/api/Users/{id}
-   * @response `200` `User` The User with the provided ID.
+   * @response `200` `User` The `User` was found and returned successfully.
    * @response `400` `ProblemDetails` Bad Request
-   * @response `404` `ProblemDetails` If no User is found with the provided ID.
+   * @response `404` `ProblemDetails` No `User` with the requested ID could be found.
    */
   usersDetail = (id: string, params: RequestParams = {}) =>
     this.request<User, ProblemDetails>({
@@ -44,11 +44,11 @@ export class Users<
    *
    * @tags Users
    * @name UsersRegisterCreate
-   * @summary Registers a new user.
+   * @summary Registers a new User.
    * @request POST:/api/Users/register
-   * @response `201` `User` The created User object.
-   * @response `400` `ProblemDetails` If the passwords don't match, or if the request is otherwise malformed.
-   * @response `409` `ProblemDetails` If login details can't be found.
+   * @response `201` `User` The `User` was registered and returned successfully.
+   * @response `400` `ProblemDetails` The passwords did not match or the request was otherwise malformed.
+   * @response `409` `ProblemDetails` A `User` with the specified username or email already exists.
    */
   usersRegisterCreate = (data: RegisterRequest, params: RequestParams = {}) =>
     this.request<User, ProblemDetails>({
@@ -64,12 +64,12 @@ export class Users<
    *
    * @tags Users
    * @name UsersLoginCreate
-   * @summary Logs a new user in.
+   * @summary Logs a User in.
    * @request POST:/api/Users/login
-   * @response `200` `LoginResponse` A <code>LoginResponse</code> object.
-   * @response `400` `ProblemDetails` If the request is malformed.
-   * @response `401` `ProblemDetails` If the wrong details were passed.
-   * @response `404` `ProblemDetails` If a User can't be found.
+   * @response `200` `LoginResponse` The `User` was logged in successfully. A `LoginResponse` is returned.
+   * @response `400` `ProblemDetails` The request was malformed.
+   * @response `401` `ProblemDetails` The password passed was incorrect.
+   * @response `404` `ProblemDetails` No `User` with the requested details could be found.
    */
   usersLoginCreate = (data: LoginRequest, params: RequestParams = {}) =>
     this.request<LoginResponse, ProblemDetails>({
@@ -81,14 +81,14 @@ export class Users<
       ...params,
     })
   /**
-   * @description <p>You <em>must</em> call this with the 'Authorization' header, passing a valid JWT bearer token. </p> <p>I.e. <code>{ 'Authorization': 'Bearer JWT' }</code></p>
+   * @description Call this method with the 'Authorization' header. A valid JWT bearer token must be passed.<br /> Example: `{ 'Authorization': 'Bearer JWT' }`.
    *
    * @tags Users
    * @name UsersMeList
-   * @summary Gets the currently logged-in user.
+   * @summary Gets the currently logged-in User.
    * @request GET:/api/Users/me
-   * @response `200` `User` Returns with the User's details.
-   * @response `403` `ProblemDetails` If an invalid JWT was passed in.
+   * @response `200` `User` The `User` was found and returned successfully..
+   * @response `403` `ProblemDetails` An invalid JWT was passed in.
    */
   usersMeList = (params: RequestParams = {}) =>
     this.request<User, ProblemDetails>({

--- a/lib/api/UsersRoute.ts
+++ b/lib/api/UsersRoute.ts
@@ -21,14 +21,20 @@ export namespace Users {
    * No description
    * @tags Users
    * @name UsersDetail
-   * @summary Gets a User by ID.
+   * @summary Gets a User by their ID.
    * @request GET:/api/Users/{id}
-   * @response `200` `User` The User with the provided ID.
+   * @response `200` `User` The `User` was found and returned successfully.
    * @response `400` `ProblemDetails` Bad Request
-   * @response `404` `ProblemDetails` If no User is found with the provided ID.
+   * @response `404` `ProblemDetails` No `User` with the requested ID could be found.
    */
   export namespace UsersDetail {
-    export type RequestParams = { id: string }
+    export type RequestParams = {
+      /**
+       * The ID of the `User` which should be retrieved.
+       * @format uuid
+       */
+      id: string
+    }
     export type RequestQuery = {}
     export type RequestBody = never
     export type RequestHeaders = {}
@@ -39,11 +45,11 @@ export namespace Users {
    * No description
    * @tags Users
    * @name UsersRegisterCreate
-   * @summary Registers a new user.
+   * @summary Registers a new User.
    * @request POST:/api/Users/register
-   * @response `201` `User` The created User object.
-   * @response `400` `ProblemDetails` If the passwords don't match, or if the request is otherwise malformed.
-   * @response `409` `ProblemDetails` If login details can't be found.
+   * @response `201` `User` The `User` was registered and returned successfully.
+   * @response `400` `ProblemDetails` The passwords did not match or the request was otherwise malformed.
+   * @response `409` `ProblemDetails` A `User` with the specified username or email already exists.
    */
   export namespace UsersRegisterCreate {
     export type RequestParams = {}
@@ -57,12 +63,12 @@ export namespace Users {
    * No description
    * @tags Users
    * @name UsersLoginCreate
-   * @summary Logs a new user in.
+   * @summary Logs a User in.
    * @request POST:/api/Users/login
-   * @response `200` `LoginResponse` A <code>LoginResponse</code> object.
-   * @response `400` `ProblemDetails` If the request is malformed.
-   * @response `401` `ProblemDetails` If the wrong details were passed.
-   * @response `404` `ProblemDetails` If a User can't be found.
+   * @response `200` `LoginResponse` The `User` was logged in successfully. A `LoginResponse` is returned.
+   * @response `400` `ProblemDetails` The request was malformed.
+   * @response `401` `ProblemDetails` The password passed was incorrect.
+   * @response `404` `ProblemDetails` No `User` with the requested details could be found.
    */
   export namespace UsersLoginCreate {
     export type RequestParams = {}
@@ -73,13 +79,13 @@ export namespace Users {
   }
 
   /**
-   * @description <p>You <em>must</em> call this with the 'Authorization' header, passing a valid JWT bearer token. </p> <p>I.e. <code>{ 'Authorization': 'Bearer JWT' }</code></p>
+   * @description Call this method with the 'Authorization' header. A valid JWT bearer token must be passed.<br /> Example: `{ 'Authorization': 'Bearer JWT' }`.
    * @tags Users
    * @name UsersMeList
-   * @summary Gets the currently logged-in user.
+   * @summary Gets the currently logged-in User.
    * @request GET:/api/Users/me
-   * @response `200` `User` Returns with the User's details.
-   * @response `403` `ProblemDetails` If an invalid JWT was passed in.
+   * @response `200` `User` The `User` was found and returned successfully..
+   * @response `403` `ProblemDetails` An invalid JWT was passed in.
    */
   export namespace UsersMeList {
     export type RequestParams = {}

--- a/lib/api/data-contracts.ts
+++ b/lib/api/data-contracts.ts
@@ -9,413 +9,481 @@
  * ---------------------------------------------------------------
  */
 
+/**
+ * Represents a site-scoped or `Leaderboard`-scoped `Ban` tied to a `User`.
+ */
 export interface Ban {
   /**
+   * The unique identifier of the `Ban`.<br />
    * Generated on creation.
    * @format int64
    */
   id?: number
-
-  /** Can't be <code>null</code>. */
-  reason: string
-
+  createdAt: Instant
+  deletedAt?: Instant
   /**
-   * Generated on creation.
-   * @format date-time
-   */
-  time: string
-
-  /**
-   * ID of User who set the Ban. Must be either an admin or a mod.
+   * The ID of the `User` who issued the `Ban`.<br />
+   * Must be a *Moderator* or *Administrator*.
    * @format uuid
    */
   banningUserId?: string | null
-
   /**
-   * ID of User who received the Ban.
+   * The ID of the `User` who received the `Ban`.
    * @format uuid
    */
   bannedUserId: string
-
   /**
-   * ID of Leaderboard this Ban belongs to. If <code>null</code>, then this Ban is site-wide.
+   * ID of the `Leaderboard` the `Ban` belongs to.<br />
+   * If this value is null, the `Ban` is site-wide.
    * @format int64
    */
   leaderboardId?: number | null
+  /**
+   * The reason for the issued `Ban`.<br />
+   * Must not be null.
+   */
+  reason: string
+}
+
+export interface CalendarSystem {
+  id?: string | null
+  name?: string | null
+  /** @format int32 */
+  minYear?: number
+  /** @format int32 */
+  maxYear?: number
+  eras?: Era[] | null
 }
 
 /**
- * A Category tied to a Leaderboard.
+ * Represents a `Category` tied to a `Leaderboard`.
  */
 export interface Category {
   /**
-   * The Category's ID. Generated on creation.
+   * The unique identifier of the `Category`.<br />
+   * Generated on creation.
    * @format int64
    */
   id?: number
-
   /**
-   * The Category's name.
-   * @example Mongolian Throat Singing%
-   */
-  name: string
-
-  /**
-   * The Category's slug. <br />
-   * Must be 2-25 characters inclusive and only consist of letters, numbers, and
-   * hyphens.
-   * @example mongolian-throat-singing
-   */
-  slug: string
-
-  /** Category-specific rules. */
-  rules?: string | null
-
-  /**
-   * Minimum player count for this Category. Defaults to 1.
-   * @format int32
-   */
-  playersMin: number
-
-  /**
-   * Maximum player count for this Category. Defaults to PlayersMin.
-   * @format int32
-   */
-  playersMax: number
-
-  /**
-   * ID of the Leaderboard this Category belongs to.
+   * The ID of the `Leaderboard` the `Category` is a part of.
    * @format int64
    */
   leaderboardId: number
+  /**
+   * The display name of the `Category`.
+   * @example Foo Bar Baz%
+   */
+  name: string
+  /**
+   * The URL-scoped unique identifier of the `Category`.<br />
+   * Must be [2, 25] in length and consist only of alphanumeric characters and hyphens.
+   * @example foo-bar-baz
+   */
+  slug: string
+  /**
+   * The rules of the `Category`.
+   * @example Video proof is required.
+   */
+  rules?: string | null
+  /**
+   * The minimum player count of the `Category`. The default is 1.
+   * @format int32
+   */
+  playersMin: number
+  /**
+   * The maximum player count of the `Category`. The default is `PlayersMin`.
+   * @format int32
+   */
+  playersMax: number
 }
 
 /**
- * Request object sent when creating a Category.
+ * This request object is sent when creating a `Category`.
  */
 export interface CreateCategoryRequest {
   /**
-   * Name for the new Category.
-   * @example Mongolian Throat Singing%
+   * The display name of the `Category`.
+   * @example Foo Bar Baz%
    */
   name: string
-
   /**
-   * The bit in the URL that uniquely identifies this Category. <br />
-   * E.g.: https://leaderboards.gg/slug-for-board/slug-for-category <br />
-   * Must be 2-25 characters inclusive and only consist of letters, numbers, and
-   * hyphens.
-   * @example mongolian-throat-singing
+   * The URL-scoped unique identifier of the `Category`.<br />
+   * Must be [2, 25] in length and consist only of alphanumeric characters and hyphens.
+   * @example foo-bar-baz
    */
   slug: string
-
-  /** Category-specific rules. */
-  rules?: string | null
-
   /**
-   * Minimum player count for this Category. Defaults to 1.
+   * The rules of the `Category`.
+   * @example Video proof is required.
+   */
+  rules?: string | null
+  /**
+   * The minimum player count of the `Category`. The default is 1.
    * @format int32
    * @min 1
    * @max 2147483647
    */
   playersMin?: number | null
-
   /**
-   * Maximum player count for this Category. Defaults to PlayersMin.
+   * The maximum player count of the `Category`. The default is `PlayersMin`.
    * @format int32
    * @min 1
    * @max 2147483647
    */
   playersMax?: number | null
-
   /**
-   * ID of the Leaderboard this Category belongs to.
+   * The ID of the `Leaderboard` the `Category` is a part of.
    * @format int64
    */
   leaderboardId: number
 }
 
 /**
- * Request object sent when creating a Judgement.
+ * This request object is sent when creating a `Judgement`.
  */
 export interface CreateJudgementRequest {
   /**
-   * GUID of the run.
+   * The ID of the `Run` that is being judged.
    * @format uuid
-   * @example e1c010d7-b499-4196-be17-aa27a053f3dc
    */
   runId?: string
-
   /**
-   * Judgement comments. Must be provided if not outright approving a run ("Approved" is false or null).
-   * Acts as mod feedback for the runner.
-   * @example e1c010d7-b499-4196-be17-aa27a053f3dc
+   * A comment elaborating on the `Judgement`'s decision. Must have a value when the
+   * affected `Run` is not approved (`Approved` is null or false).
+   * @example The video proof is not of sufficient quality.
    */
   note?: string | null
-
-  /** The judgement result. Can be true, false, or null. For the latter two, "Note" must be non-empty. */
+  /** The `Judgement`'s decision. May be null, true, or false. */
   approved?: boolean | null
 }
 
+/**
+ * This request object is sent when banning a `User` from a `Leaderboard`.
+ */
 export interface CreateLeaderboardBanRequest {
   /**
-   * The ID of the user, who should be banned.
+   * The ID of the `User` which is banned.
    * @format uuid
    */
   userId: string
-
-  /** The reason why the user is banned. */
-  reason: string
-
   /**
-   * The ID of the leaderboard on which the user should be banned.
+   * The reason for the `User`'s ban.
+   * @example Abusive or hateful conduct.
+   */
+  reason: string
+  /**
+   * The ID of the `Leaderboard` from which the `User` is banned.
    * @format int64
    */
-  leaderboardId?: number
+  leaderboardId: number
 }
 
+/**
+ * This request object is sent when creating a `Leaderboard`.
+ */
 export interface CreateLeaderboardRequest {
+  /**
+   * The display name of the `Leaderboard` to create.
+   * @example Foo Bar
+   */
   name?: string | null
+  /**
+   * The URL-scoped unique identifier of the `Leaderboard`.<br />
+   * Must be [2, 80] in length and consist only of alphanumeric characters and hyphens.
+   * @example foo-bar
+   */
   slug?: string | null
 }
 
 /**
- * Request object sent when setting a User as mod for a Leaderboard.
+ * This request object is sent when promoting a `User` to *Moderator* for a `Leaderboard`.
  */
 export interface CreateModshipRequest {
   /**
-   * The Leaderboard ID.
+   * The ID of the `Leaderboard` the `User` should become a *Moderator* for.
    * @format int64
    */
   leaderboardId: number
-
   /**
-   * The User ID.
+   * The ID of the `User` who should be promoted.
    * @format uuid
    */
   userId: string
-}
-
-export interface CreateParticipationRequest {
-  comment?: string | null
-  vod?: string | null
-
-  /** @format uuid */
-  runnerId: string
-
-  /** @format uuid */
-  runId: string
-  isSubmitter: boolean
-}
-
-export interface CreateRunRequest {
-  /** @format date-time */
-  played: string
-
-  /** @format date-time */
-  submitted: string
-
-  /**
-   * 0: Created
-   * 1: Submitted
-   * 2: Pending
-   * 3: Approved
-   * 4: Rejected
-   */
-  status: RunStatus
-}
-
-export interface CreateSiteBanRequest {
-  /**
-   * The ID of the user, who should be banned.
-   * @format uuid
-   */
-  userId: string
-
-  /** The reason why the user is banned. */
-  reason: string
 }
 
 /**
- * A decision by a mod on a run submission.
+ * This request object is sent when creating a `Participation` for a `User` on a `Run`.
+ */
+export interface CreateParticipationRequest {
+  /** An optional comment about the `Participation`. */
+  comment?: string | null
+  /** An optional link to video proof of the `Run`. */
+  vod?: string | null
+  /**
+   * The ID of the `User` who is participating.
+   * @format uuid
+   */
+  runnerId: string
+  /**
+   * The ID of the `Run` the `Participation` is created on.
+   * @format uuid
+   */
+  runId: string
+  /** Indicates whether the `Participation` is for the `User` who is creating it. */
+  isSubmitter: boolean
+}
+
+/**
+ * This request object is sent when creating a `Run`.
+ */
+export interface CreateRunRequest {
+  playedOn: LocalDate
+  submittedAt: Instant
+  /**
+   * The status of the `Run`.<br />
+   *     - 0: Created<br />
+   *     - 1: Submitted<br />
+   *     - 2: Pending<br />
+   *     - 3: Approved<br />
+   *     - 4: Rejected
+   */
+  status: RunStatus
+  /**
+   * The ID of the `Category` for the `Run`.
+   * @format int64
+   */
+  categoryId: number
+}
+
+/**
+ * This request object is sent when banning a `User` from the site.
+ */
+export interface CreateSiteBanRequest {
+  /**
+   * The ID of the `User` which is banned.
+   * @format uuid
+   */
+  userId: string
+  /**
+   * The reason as to the `User`'s ban.
+   * @example Abusive or hateful conduct.
+   */
+  reason: string
+}
+
+export interface Era {
+  name?: string | null
+}
+
+export type Instant = object
+
+/**
+ * @format int32
+ */
+export type IsoDayOfWeek = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7
+
+/**
+ * Represents a decision made by a *Moderator* (`User`) about a `Run`.
  */
 export interface Judgement {
   /**
+   * The unique identifier of the `Judgement`.<br />
    * Generated on creation.
    * @format int64
    */
   id?: number
-
+  createdAt: Instant
   /**
-   * Defines this judgement, which in turn defines the status of its related run. <br />
-   * If:
-   *   <ul><li>true, run is approved;</li><li>false, run is rejected;</li><li>null, run is commented on.</li></ul>
-   * For the latter two, Note MUST be non-empty.
-   */
-  approved?: boolean | null
-
-  /**
-   * When the judgement was made.
-   * @format date-time
-   */
-  createdAt: string
-
-  /**
-   * Comments on the judgement.
-   * MUST be non-empty for rejections or comments (Approved ∈ {false, null}).
-   */
-  note: string
-
-  /**
-   * ID of the mod that made this judgement.
-   * @format uuid
-   */
-  modId: string
-  mod: User
-
-  /**
-   * ID of the related run.
+   * The ID of the `Run` which is being judged.
    * @format uuid
    */
   runId: string
+  /** Represents an entry on a `Category`. */
   run: Run
+  /**
+   * The ID of the *Moderator* (`User`) who is making the `Judgement`.
+   * @format uuid
+   */
+  judgeId: string
+  /** Represents a user account registered on the website. */
+  judge: User
+  /** The `Judgement`'s decision. May be null, true, or false. */
+  approved?: boolean | null
+  /**
+   * A comment elaborating on the `Judgement`'s decision. Must have a value when the
+   * affected `Run` is not approved (`Approved` is null or false).
+   * @example The video proof is not of sufficient quality.
+   */
+  note: string
 }
 
 /**
- * A decision by a mod on a run submission. See Models/Entities/Judgement.cs.
- */
+* Represents a decision made by a *Moderator* (`User`) about a `Run`.<br />
+See: LeaderboardBackend.Models.Entities.Judgement.
+*/
 export interface JudgementViewModel {
   /**
-   * The newly-made judgement's ID.
+   * The unique identifier of the `Judgement`.
    * @format int64
    */
   id?: number
-
-  /** The judgement result. Can be true, false, or null. In the latter two, <code>Note</code> will be non-empty. */
-  approved?: boolean | null
-
   /**
-   * When the judgement was made. Follows <a href="https://www.ietf.org/rfc/rfc3339.txt">RFC 3339</a>.
+   * The `Judgement`'s decision. May be null, true, or false.<br />
+   * `Note` will be non-empty when the decision is null or false.
+   */
+  approved?: boolean | null
+  /**
+   * The time the `Judgement` was made.
    * @example 2022-01-01T12:34:56Z / 2022-01-01T12:34:56+01:00
    */
   createdAt?: string | null
-
   /**
-   * Judgement comments. Acts as mod feedback for the runner. Will be non-empty for
-   * non-approval judgements (Approved is false or null).
+   * A comment elaborating on the `Judgement`'s decision. Will have a value when the
+   * affected `Run` is not approved (`Approved` is null or false).
    */
   note?: string | null
-
   /**
-   * ID of mod who made this judgement.
+   * The ID of the *Moderator* (`User`) who made the `Judgement`.
    * @format uuid
    */
   modId?: string
-
   /**
-   * ID of run this judgement's for.
+   * The ID of the `Run` which was judged.
    * @format uuid
    */
   runId?: string
 }
 
+/**
+ * Represents a collection of `Category` entities.
+ */
 export interface Leaderboard {
   /**
+   * The unique identifier of the `Leaderboard`.<br />
    * Generated on creation.
    * @format int64
    */
   id?: number
-
   /**
-   * The Leaderboard's aka game's name. Pretty straightforward.
-   * @example Mario Goes to Jail II
+   * The display name of the `Leaderboard` to create.
+   * @example Foo Bar
    */
   name: string
-
   /**
-   * The bit in the URL after the domain that can be used to identify a Leaderboard.
-   * Meant to be human-readable. It must be:
-   * <ul><li>between 2-80 characters, inclusive</li><li>a string of characters separated by hyphens, if desired</li></ul>
-   * @example mario-goes-to-jail-ii
+   * The URL-scoped unique identifier of the `Leaderboard`.<br />
+   * Must be [2, 80] in length and consist only of alphanumeric characters and hyphens.
+   * @example foo-bar
    */
   slug: string
-
   /**
-   * The general rules for the Leaderboard.<br />
-   * Category-specific rules are tied to the Category.
-   * @example Timer starts on selecting New Game and ends when the first tear drops.
+   * The general rules for the Leaderboard.
+   * @example Timer starts on selecting New Game and ends when the final boss is beaten.
    */
   rules?: string | null
 }
 
+export interface LocalDate {
+  calendar?: CalendarSystem
+  /** @format int32 */
+  year?: number
+  /** @format int32 */
+  month?: number
+  /** @format int32 */
+  day?: number
+  dayOfWeek?: IsoDayOfWeek
+  /** @format int32 */
+  yearOfEra?: number
+  era?: Era
+  /** @format int32 */
+  dayOfYear?: number
+}
+
 /**
- * Request object sent when logging a User in.
+ * This request object is sent when a `User` is attempting to log in.
  */
 export interface LoginRequest {
   /**
-   * User's email.
+   * The `User`'s email address.
    * @format email
-   * @example ayylmao.gaming@alg.gg
+   * @example john.doe@example.com
    */
   email: string
-
   /**
-   * User's password. It:
-   * <ul><li>must be 8-80 characters long, inclusive;</li><li>must have at least:</li><ul><li>an uppercase letter;</li><li>a lowercase letter; and</li><li>a number.</li></ul><li>supports Unicode.</li></ul>
+   * The `User`'s password. It:
+   * <ul><li>supports Unicode;</li><li>must be [8, 80] in length;</li><li>must have at least:</li><ul><li>one uppercase letter;</li><li>one lowercase letter; and</li><li>one number.</li></ul></ul>
    * @example P4ssword
    */
   password: string
 }
 
 /**
- * Response object received on a successful login.
+ * This response object is received upon a successful log-in request.
  */
 export interface LoginResponse {
-  /** A JWT to authenticate and authorize future queries with. */
+  /** A JSON Web Token to authenticate and authorize queries with. */
   token: string
 }
 
+/**
+ * Represents the *Moderator* status of a `User`.
+ */
 export interface Modship {
   /**
+   * The unique identifier of the `Modship`.<br />
    * Generated on creation.
    * @format int64
    */
   id?: number
-
   /**
-   * The mod's ID.
+   * The ID of the *Moderator* (`User`).
    * @format uuid
    */
   userId: string
+  /** Represents a user account registered on the website. */
   user?: User
-
   /**
-   * ID of the Leaderboard the User is a mod for.
+   * The ID of the `Leaderboard` the `User` is a *Moderator* for.
    * @format int64
    */
   leaderboardId: number
+  /** Represents a collection of `Category` entities. */
   leaderboard?: Leaderboard
 }
 
+/**
+ * Represents the participation of a `User` on a `Run`.
+ */
 export interface Participation {
-  /** @format int64 */
+  /**
+   * The unique identifier of the `Participation`.<br />
+   * Generated on creation.
+   * @format int64
+   */
   id?: number
-  comment?: string | null
-  vod?: string | null
-
-  /** @format uuid */
+  /**
+   * The ID of the `User` who is participating.
+   * @format uuid
+   */
   runnerId: string
+  /** Represents a user account registered on the website. */
   runner: User
-
-  /** @format uuid */
+  /**
+   * The ID of the `Run` the `Participation` is created on.
+   * @format uuid
+   */
   runId: string
+  /** Represents an entry on a `Category`. */
   run: Run
+  /** An optional comment about the `Participation`. */
+  comment?: string | null
+  /** An optional link to video proof of the `Run`. */
+  vod?: string | null
 }
 
 export interface ProblemDetails {
   type?: string | null
   title?: string | null
-
   /** @format int32 */
   status?: number | null
   detail?: string | null
@@ -423,128 +491,145 @@ export interface ProblemDetails {
 }
 
 /**
- * Request object sent when registering a User.
+ * This request object is sent when a `User` is attempting to register.
  */
 export interface RegisterRequest {
   /**
-   * The username to register with. It must be:
-   *   <ul><li>2-25 characters long, inclusive;</li><li>made up of letters sandwiching zero or one of:</li><ul><li>hyphen;</li><li>underscore; or</li><li>apostrophe</li></ul></ul>
-   * Usernames are also saved with casing, but matched without. This means you won't
-   * be able to register as "Cool" if someone already called "cool" exists.
+   * The username of the `User`. It:
+   * <ul><li>must be [2, 25] in length;</li><li>must be made up of letters sandwiching zero or one of:</li><ul><li>hyphen;</li><li>underscore; or</li><li>apostrophe</li></ul></ul>
+   * Usernames are saved case-sensitively, but matcehd against case-insensitively.
+   * A `User` may not register with the name 'Cool' when another `User` with the name 'cool'
+   * exists.
    * @pattern (?:[a-zA-Z0-9][-_']?){1,12}[a-zA-Z0-9]
-   * @example Ayy-l'maoGaming
+   * @example J'on-Doe
    */
   username: string
-
   /**
-   * User's email.
+   * The `User`'s email address.
    * @format email
-   * @example ayylmao.gaming@alg.gg
+   * @example john.doe@example.com
    */
   email: string
-
   /**
-   * User's password. It:
-   * <ul><li>must be 8-80 characters long, inclusive;</li><li>must have at least:</li><ul><li>an uppercase letter;</li><li>a lowercase letter; and</li><li>a number.</li></ul><li>supports Unicode.</li></ul>
+   * The `User`'s password. It:
+   * <ul><li>supports Unicode;</li><li>must be [8, 80] in length;</li><li>must have at least:</li><ul><li>one uppercase letter;</li><li>one lowercase letter; and</li><li>one number.</li></ul></ul>
    * @example P4ssword
    */
   password: string
-
-  /**
-   * Password confirmation. It must match <code>password</code>.
-   * @example P4ssword
-   */
+  /** The password confirmation. This value must match `Password`. */
   passwordConfirm: string
 }
 
 /**
- * Request object sent when removing a User as mod for a Leaderboard.
+ * This request object is sent when demoting a `User` as a *Moderator* from a `Leaderboard`.
  */
 export interface RemoveModshipRequest {
   /**
-   * The Leaderboard ID.
+   * The ID of the `Leaderboard` the `User` should be demoted from.
    * @format int64
    */
   leaderboardId: number
-
   /**
-   * The User ID.
+   * The ID of the `User` who should be demoted.
    * @format uuid
    */
   userId: string
 }
 
+/**
+ * Represents an entry on a `Category`.
+ */
 export interface Run {
-  /** @format uuid */
-  id?: string
-
-  /** @format date-time */
-  played: string
-
-  /** @format date-time */
-  submitted: string
-
   /**
-   * 0: Created
-   * 1: Submitted
-   * 2: Pending
-   * 3: Approved
-   * 4: Rejected
+   * The unique identifier of the `Run`.<br />
+   * Generated on creation.
+   * @format uuid
+   */
+  id?: string
+  playedOn: LocalDate
+  submittedAt: Instant
+  /**
+   * The status of the `Run`.<br />
+   *     - 0: Created<br />
+   *     - 1: Submitted<br />
+   *     - 2: Pending<br />
+   *     - 3: Approved<br />
+   *     - 4: Rejected
    */
   status: RunStatus
+  /** A collection of `Judgement`s made about the `Run`. */
   judgements?: Judgement[] | null
+  /** A collection of `Participation`s on the `Run`. */
   participations: Participation[]
+  /**
+   * The ID of the `Category` for `Run`.
+   * @format int64
+   */
+  categoryId: number
+  /** Represents a `Category` tied to a `Leaderboard`. */
+  category?: Category
 }
 
 /**
-* 0: Created
-1: Submitted
-2: Pending
-3: Approved
-4: Rejected
+* The status of the `Run`.<br />
+    - 0: Created<br />
+    - 1: Submitted<br />
+    - 2: Pending<br />
+    - 3: Approved<br />
+    - 4: Rejected
 * @format int32
 */
 export type RunStatus = 0 | 1 | 2 | 3 | 4
 
+/**
+ * This request object is sent when updating a `Participation`.
+ */
 export interface UpdateParticipationRequest {
+  /** A comment about the `Participation`. */
   comment?: string | null
+  /** A link to video proof of the `Run`. */
   vod: string
 }
 
+/**
+ * Represents a user account registered on the website.
+ */
 export interface User {
   /**
-   * A GUID that identifies the User. Generated on creation.
+   * The unique identifier of the `User`.<br />
+   * Generated on creation.
    * @format uuid
-   * @example 4b3835ca-dee1-4019-82b4-d2d26a7cce74
    */
   id?: string
-
   /**
-   * The User's name. Must be:
-   * <ul><li>between 2 - 25 characters inclusive; and</li><li>an alphanumeric sequence, each separated by zero or one of:</li><ul><li>an underscore;</li><li>a hyphen; or</li><li>an apostrophe</li></ul></ul>
-   * Saving a name is case-sensitive, but matching against existing Users won't be.
-   * @example Ayylmao Gaming
+   * The username of the `User`. It:
+   * <ul><li>must be [2, 25] in length;</li><li>must be made up of alphanumeric characters around zero or one of:</li><ul><li>hyphen;</li><li>underscore; or</li><li>apostrophe</li></ul></ul>
+   * Usernames are saved case-sensitively, but matcehd against case-insensitively.
+   * A `User` may not register with the name 'Cool' when another `User` with the name 'cool'
+   * exists.
+   * @example J'on-Doe
    */
   username: string
-
   /**
-   * The User's email. Must be, well, an email.
-   * @example ayylmao.gaming@alg.gg
+   * The `User`'s email address.
+   * @example john.doe@example.com
    */
   email: string
-
-  /** User's about text. I.e. a personal description. */
+  /** The `User`'s personal description, displayed on their profile. */
   about?: string | null
-
-  /** User's admin status. */
+  /** The `User`'s administrator status. */
   admin: boolean
+  /** The `Ban`s the `User` has issued. */
   bansGiven?: Ban[] | null
+  /** The `Ban`s the `User` has received. */
   bansReceived?: Ban[] | null
+  /** The `Modship`s associated with the `User`. */
   modships?: Modship[] | null
+  /** The `Participation`s associated with the `User`. */
   participations?: Participation[] | null
 }
 
 export interface LeaderboardsListParams {
-  /** The IDs. */
+  /** The IDs of the `Leaderboard`s which should be retrieved. */
   ids?: number[]
 }

--- a/lib/api/http-client.ts
+++ b/lib/api/http-client.ts
@@ -82,18 +82,18 @@ export class HttpClient<SecurityDataType = unknown> {
     this.securityData = data
   }
 
-  private encodeQueryParam(key: string, value: any) {
+  protected encodeQueryParam(key: string, value: any) {
     const encodedKey = encodeURIComponent(key)
     return `${encodedKey}=${encodeURIComponent(
       typeof value === 'number' ? value : `${value}`,
     )}`
   }
 
-  private addQueryParam(query: QueryParamsType, key: string) {
+  protected addQueryParam(query: QueryParamsType, key: string) {
     return this.encodeQueryParam(key, query[key])
   }
 
-  private addArrayQueryParam(query: QueryParamsType, key: string) {
+  protected addArrayQueryParam(query: QueryParamsType, key: string) {
     const value = query[key]
     return value.map((v: any) => this.encodeQueryParam(key, v)).join('&')
   }
@@ -138,7 +138,7 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),
   }
 
-  private mergeRequestParams(
+  protected mergeRequestParams(
     params1: RequestParams,
     params2?: RequestParams,
   ): RequestParams {
@@ -154,7 +154,7 @@ export class HttpClient<SecurityDataType = unknown> {
     }
   }
 
-  private createAbortSignal = (
+  protected createAbortSignal = (
     cancelToken: CancelToken,
   ): AbortSignal | undefined => {
     if (this.abortControllers.has(cancelToken)) {
@@ -207,12 +207,14 @@ export class HttpClient<SecurityDataType = unknown> {
       {
         ...requestParams,
         headers: {
+          ...(requestParams.headers || {}),
           ...(type && type !== ContentType.FormData
             ? { 'Content-Type': type }
             : {}),
-          ...(requestParams.headers || {}),
         },
-        signal: cancelToken ? this.createAbortSignal(cancelToken) : void 0,
+        signal: cancelToken
+          ? this.createAbortSignal(cancelToken)
+          : requestParams.signal,
         body:
           typeof body === 'undefined' || body === null
             ? null

--- a/pages/index.test.ts
+++ b/pages/index.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import { mount } from '@vue/test-utils'
 
 import index from 'pages/index.vue'
@@ -12,11 +11,11 @@ describe('/index', () => {
     },
   })
 
-  test('should render without crashing', () => {
+  it('should render without crashing', () => {
     expect(IndexWrapper.isVisible()).toBe(true)
   })
 
-  test('should render the placeholder text', () => {
+  it('should render the placeholder text', () => {
     expect(
       IndexWrapper.html().includes(
         'This is just a primary content placeholder.',

--- a/testUtils.ts
+++ b/testUtils.ts
@@ -1,29 +1,3 @@
-// TODO: either use and expand this for testing or remove this if we decide against it
-
-// import { createElementBlock, Component, ComponentOptions } from 'vue'
-// import { MountingOptions } from '@vue/test-utils'
-// import userEvent from '@testing-library/user-event'
-// import { render, RenderOptions } from '@testing-library/vue'
-
-// export const stubbedRender = (
-//   Component: Component | ComponentOptions,
-//   options?: RenderOptions | MountingOptions<any>,
-// ) => {
-//   return render(Component, {
-//     global: {
-//       stubs: {
-//         NuxtLink: createElementBlock('a'),
-//       },
-//     },
-//     ...options,
-//   })
-// }
-
-// export * from '@testing-library/vue'
-// export * from '@nuxt/test-utils-edge'
-// export * from '@vue/test-utils'
-// export { userEvent as fireEvent }
-
 import { DOMWrapper, VueWrapper } from '@vue/test-utils'
 type WrappedElement = Omit<DOMWrapper<Element>, 'exists'>
 
@@ -47,7 +21,6 @@ export async function typeString(
     ...toType.split('').map((c) =>
       wrappedElement.trigger('keyup', {
         key: c,
-        // keyCode: c.charCodeAt(0),
       }),
     ),
   ])

--- a/testUtils.ts
+++ b/testUtils.ts
@@ -23,3 +23,32 @@
 // export * from '@nuxt/test-utils-edge'
 // export * from '@vue/test-utils'
 // export { userEvent as fireEvent }
+
+import { DOMWrapper, VueWrapper } from '@vue/test-utils'
+type WrappedElement = Omit<DOMWrapper<Element>, 'exists'>
+
+export function getByTestId(
+  wrapper: VueWrapper<any>,
+  testId: string,
+): WrappedElement {
+  return wrapper.get(`[data-testid="${testId}"]`)
+}
+
+export function getHTMLElement(wrappedElement: WrappedElement): HTMLElement {
+  return wrappedElement.getRootNodes()[0] as HTMLElement
+}
+
+export async function typeString(
+  wrappedElement: WrappedElement,
+  toType: string,
+): Promise<void> {
+  Promise.all([
+    wrappedElement.trigger('click'),
+    ...toType.split('').map((c) =>
+      wrappedElement.trigger('keyup', {
+        key: c,
+        // keyCode: c.charCodeAt(0),
+      }),
+    ),
+  ])
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,10 @@
 /// <reference types="vitest" />
+import { resolve } from 'path'
 import { mergeConfig } from 'vite'
 import { defineConfig } from 'vitest/config'
 import ViteConfig from './vite.config'
 import Vue from '@vitejs/plugin-vue'
+import VueJsx from '@vitejs/plugin-vue-jsx'
 
 // TODO: https://github.com/leaderboardsgg/leaderboard-site/issues/503
 
@@ -25,7 +27,17 @@ export default mergeConfig(
           },
         },
       }),
+      VueJsx(),
     ],
+    resolve: {
+      alias: {
+        // '#app': resolve(__dirname, './node_modules/.pnpm/nuxt@3.0.0-rc.12_wyqvi574yv7oiwfeinomdzmc3m/node_modules/nuxt/dist/app'),
+        '#app': resolve(__dirname, './node_modules/nuxt/dist/app'),
+        // '#app': resolve(__dirname, './.nuxt/app'),
+        // '#build': resolve(__dirname, './.nuxt'),
+        // ...baseTsConfig.compilerOptions.paths,
+      },
+    },
     test: {
       environment: 'happy-dom',
       globals: true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,6 +28,10 @@ export default mergeConfig(
     ],
     test: {
       environment: 'happy-dom',
+      globals: true,
+      sequence: {
+        shuffle: false, // change back to true later
+      },
       setupFiles: ['vitest.setup.ts'],
     },
   }),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -35,11 +35,7 @@ export default mergeConfig(
     ],
     resolve: {
       alias: {
-        // '#app': resolve(__dirname, './node_modules/.pnpm/nuxt@3.0.0-rc.12_wyqvi574yv7oiwfeinomdzmc3m/node_modules/nuxt/dist/app'),
         '#app': resolve(__dirname, './node_modules/nuxt/dist/app'),
-        // '#app': resolve(__dirname, './.nuxt/app'),
-        // '#build': resolve(__dirname, './.nuxt'),
-        // ...baseTsConfig.compilerOptions.paths,
       },
     },
     test: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,11 +1,17 @@
 /// <reference types="vitest" />
 import { resolve } from 'path'
+import * as dotenv from 'dotenv-safe'
 import { mergeConfig } from 'vite'
 import { defineConfig } from 'vitest/config'
 import ViteConfig from './vite.config'
 import Vue from '@vitejs/plugin-vue'
 
 // TODO: https://github.com/leaderboardsgg/leaderboard-site/issues/503
+
+const { parsed } = dotenv.config({
+  example: resolve(__dirname, '.env.example'),
+  path: resolve(__dirname, '.env.test'),
+})
 
 export default mergeConfig(
   ViteConfig,
@@ -38,6 +44,7 @@ export default mergeConfig(
     },
     test: {
       environment: 'happy-dom',
+      env: parsed,
       globals: true,
       sequence: {
         shuffle: false, // change back to true later

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,6 @@ import { mergeConfig } from 'vite'
 import { defineConfig } from 'vitest/config'
 import ViteConfig from './vite.config'
 import Vue from '@vitejs/plugin-vue'
-import VueJsx from '@vitejs/plugin-vue-jsx'
 
 // TODO: https://github.com/leaderboardsgg/leaderboard-site/issues/503
 
@@ -27,7 +26,6 @@ export default mergeConfig(
           },
         },
       }),
-      VueJsx(),
     ],
     resolve: {
       alias: {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,4 +1,4 @@
-// import { enableAutoUnmount } from '@vue/test-utils'
+import { config } from '@vue/test-utils'
 import createFetchMock from 'vitest-fetch-mock'
 import { vi } from 'vitest'
 import type { Ref } from 'vue'
@@ -25,7 +25,7 @@ fetchMock.enableMocks()
 const payload = reactive<{ state: Record<string, any> }>({
   state: {},
 })
-const useStateMock = vi.fn((key: string, init?: () => any) => {
+export const useStateMock = vi.fn((key: string, init?: () => any) => {
   const state = toRef(payload.state, key)
   if (state.value === undefined && init) {
     const initialValue = init()
@@ -44,3 +44,7 @@ vi.stubGlobal('useRuntimeConfig', () => ({
     BACKEND_BASE_URL: process.env.BACKEND_BASE_URL,
   },
 }))
+
+config.global.mocks = {
+  $t: (msg: any) => msg,
+}

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,5 +1,8 @@
+// import { enableAutoUnmount } from '@vue/test-utils'
 import createFetchMock from 'vitest-fetch-mock'
 import { vi } from 'vitest'
+import type { Ref } from 'vue'
+import { reactive, isRef, toRef } from 'vue'
 
 // TODO: use this/ change this when we need to add environment variables into the tests
 // import { config } from 'dotenv-safe'
@@ -9,3 +12,35 @@ const fetchMock = createFetchMock(vi)
 
 // sets globalThis.fetch and globalThis.fetchMock to our mocked version
 fetchMock.enableMocks()
+
+// enableAutoUnmount(afterEach)
+
+// export * from './node_modules/nuxt/dist/app/composables'
+// export { useState } from './node_modules/nuxt/dist/app/composables/state'
+// export { useState } from '.nuxt/imports'
+// export { useState } from 'nuxt/app'
+
+// Stolen from here:
+// https://zenn.dev/ninebolt6/articles/cadc924cb2416d
+const payload = reactive<{ state: Record<string, any> }>({
+  state: {},
+})
+const useStateMock = vi.fn((key: string, init?: () => any) => {
+  const state = toRef(payload.state, key)
+  if (state.value === undefined && init) {
+    const initialValue = init()
+    if (isRef(initialValue)) {
+      payload.state[key] = initialValue
+      return initialValue as Ref<any>
+    }
+    state.value = initialValue
+  }
+  return state
+})
+vi.stubGlobal('useState', useStateMock)
+
+vi.stubGlobal('useRuntimeConfig', () => ({
+  public: {
+    BACKEND_BASE_URL: process.env.BACKEND_BASE_URL,
+  },
+}))

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -4,10 +4,6 @@ import { vi } from 'vitest'
 import type { Ref } from 'vue'
 import { reactive, isRef, toRef } from 'vue'
 
-// TODO: use this/ change this when we need to add environment variables into the tests
-// import { config } from 'dotenv-safe'
-// config({ path: '.env.test' })
-
 const fetchMock = createFetchMock(vi)
 
 // sets globalThis.fetch and globalThis.fetchMock to our mocked version

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -9,13 +9,6 @@ const fetchMock = createFetchMock(vi)
 // sets globalThis.fetch and globalThis.fetchMock to our mocked version
 fetchMock.enableMocks()
 
-// enableAutoUnmount(afterEach)
-
-// export * from './node_modules/nuxt/dist/app/composables'
-// export { useState } from './node_modules/nuxt/dist/app/composables/state'
-// export { useState } from '.nuxt/imports'
-// export { useState } from 'nuxt/app'
-
 // Stolen from here:
 // https://zenn.dev/ninebolt6/articles/cadc924cb2416d
 const payload = reactive<{ state: Record<string, any> }>({


### PR DESCRIPTION
## What

After removing the `testing-library` packages from the repo, in favour of using the baseline `@vue/test-utils`, nearly all of our tests needed to be re-written in one way or another.

- Added
  - some helper methods to the `testUtils` to make writing tests easier
- Updated
  - configs/setup for `vitest`
  - the `lib/api` 
  - _lots of tests_
    - basically at testing parity of when we were on Nuxt 2
    - only one test from back then isn't currently passing, but it's not a huge concern at the moment

## Link to Issue
N/A

## Acceptance

### Steps for testing

We can rely on the Github workflow for this

