### PR TITLE
Vitest test isolation and sequence.shuffle set to true

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -1,27 +1,18 @@
-name: CI
-
+name: CI - Build & Linting
 on:
   push:
     branches: [main]
   pull_request:
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}-testing
+  group: ${{ github.head_ref || github.run_id }}-build-and-lint
   cancel-in-progress: true
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  test:
+  build_and_lint:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
-    continue-on-error: true
-
-    strategy:
-      fail-fast: false
-      max-parallel: 2
-      matrix:
-        run_number: [1, 2, 3, 4, 5, 6, 7, 8]
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -73,5 +64,8 @@ jobs:
         if: steps.cache-build.outputs.cache-hit != 'true'
         run: pnpm build
 
-      - name: Tests
-        run: pnpm run test
+      - name: Linting
+        run: pnpm run lint
+
+      - name: Prettier
+        run: pnpm run prettier:check

--- a/components/blocks/SearchBar/SearchBar.test.ts
+++ b/components/blocks/SearchBar/SearchBar.test.ts
@@ -1,41 +1,43 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-
-import { mount } from '@vue/test-utils'
-
-// import { VueNode } from '@vue/test-utils/dist/types'
+import { mount, enableAutoUnmount } from '@vue/test-utils'
 import SearchBar from './SearchBar.vue'
+import { getByTestId } from 'root/testUtils'
+
+function getSearchBarWrapper() {
+  return mount(SearchBar)
+}
+
+enableAutoUnmount(afterEach)
 
 describe('<SearchBar />', () => {
-  const SearchBarWrapper = mount(SearchBar)
-
   it('should render without crashing', () => {
+    const SearchBarWrapper = getSearchBarWrapper()
     expect(SearchBarWrapper.isVisible()).toBe(true)
   })
 
   describe('when the search event is emitted', () => {
-    const inputValue = 'test'
-
     it('when the search button is clicked', async () => {
-      // on `wrapper.vm` we can access any method or value
-      // @ts-expect-error
-      SearchBarWrapper.vm.state.input.value = inputValue
+      const inputValue = 'click test'
+      const SearchBarWrapper = getSearchBarWrapper()
+      const searchButton = getByTestId(SearchBarWrapper, 'search-button')
+      const searchInput = getByTestId(SearchBarWrapper, 'search-input')
 
-      await SearchBarWrapper.get('[data-testid="search-button"]').trigger(
-        'click',
-      )
+      searchInput.setValue(inputValue)
+
+      await searchButton.trigger('click')
 
       // @ts-expect-error
       expect(SearchBarWrapper.emitted()?.search[0][0]).toBe(inputValue)
     })
 
     it('when the enter key is released', async () => {
-      // on `wrapper.vm` we can access any method or value
-      // @ts-expect-error
-      SearchBarWrapper.vm.state.input.value = inputValue
+      const inputValue = 'enter test'
+      const SearchBarWrapper = getSearchBarWrapper()
+      const searchInput = getByTestId(SearchBarWrapper, 'search-input')
 
-      await SearchBarWrapper.get('[data-testid="search-button"]').trigger(
-        'keyup.enter',
-      )
+      searchInput.setValue(inputValue)
+
+      await searchInput.trigger('keyup.enter')
 
       // @ts-expect-error
       expect(SearchBarWrapper.emitted()?.search[0][0]).toBe(inputValue)

--- a/components/blocks/SiteFooter/LanguageSelector/LanguageSelector.test.ts
+++ b/components/blocks/SiteFooter/LanguageSelector/LanguageSelector.test.ts
@@ -1,15 +1,21 @@
-import { mount } from '@vue/test-utils'
+import { mount, enableAutoUnmount } from '@vue/test-utils'
 import { supportedLocales } from 'configUtils'
 import LanguageSelector from './LanguageSelector.vue'
 
-describe('<LanguageSelector />', () => {
-  const LanguageSelectorWrapper = mount(LanguageSelector)
+function getLanguageSelectorWrapper() {
+  return mount(LanguageSelector)
+}
 
+enableAutoUnmount(afterEach)
+
+describe('<LanguageSelector />', () => {
   it('should render without crashing', () => {
+    const LanguageSelectorWrapper = getLanguageSelectorWrapper()
     expect(LanguageSelectorWrapper.isVisible()).toBe(true)
   })
 
   it('should render a dropdown with all the locales as options', () => {
+    const LanguageSelectorWrapper = getLanguageSelectorWrapper()
     for (const locale of supportedLocales) {
       expect(LanguageSelectorWrapper.html()).toContain(locale.name)
     }

--- a/components/blocks/SiteFooter/SiteFooter.test.ts
+++ b/components/blocks/SiteFooter/SiteFooter.test.ts
@@ -1,15 +1,21 @@
-import { mount } from '@vue/test-utils'
+import { mount, enableAutoUnmount } from '@vue/test-utils'
 
 import SiteFooter from './SiteFooter.vue'
 
-describe('<SiteFooter />', () => {
-  const SiteFooterWrapper = mount(SiteFooter)
+function getSiteFooterWrapper() {
+  return mount(SiteFooter)
+}
 
+enableAutoUnmount(afterEach)
+
+describe('<SiteFooter />', () => {
   it('should render without crashing', () => {
+    const SiteFooterWrapper = getSiteFooterWrapper()
     expect(SiteFooterWrapper.isVisible()).toBe(true)
   })
 
   it('renders correctly with the copyright info', () => {
+    const SiteFooterWrapper = getSiteFooterWrapper()
     expect(SiteFooterWrapper.html()).toContain(
       `Copyright ${new Date().getFullYear()}`,
     )

--- a/components/blocks/cards/LogInCard/LogInCard.test.ts
+++ b/components/blocks/cards/LogInCard/LogInCard.test.ts
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils'
+import { mount, enableAutoUnmount } from '@vue/test-utils'
 import LogInCard from './LogInCard.vue'
 import { FullRequestParams } from 'lib/api/http-client'
 import { getByTestId, getHTMLElement } from 'testUtils'
@@ -6,10 +6,16 @@ import { getByTestId, getHTMLElement } from 'testUtils'
 const token = 'jwt-token'
 type fetchMockCall = [string, FullRequestParams]
 
+function getLogInCardWrapper() {
+  return mount(LogInCard)
+}
+
 afterEach(() => {
   fetchMock.resetMocks()
   vi.restoreAllMocks()
 })
+
+enableAutoUnmount(afterEach)
 
 describe('<LogInCard />', () => {
   beforeEach(() => {
@@ -17,14 +23,14 @@ describe('<LogInCard />', () => {
   })
 
   it('should render without crashing', () => {
-    const wrapper = mount(LogInCard)
+    const wrapper = getLogInCardWrapper()
 
     expect(wrapper.isVisible()).toBe(true)
   })
 
   describe('when the close button is clicked', () => {
     it('should emit the close event', async () => {
-      const wrapper = mount(LogInCard)
+      const wrapper = getLogInCardWrapper()
 
       const closeButton = getByTestId(wrapper, 'close-button')
 
@@ -36,7 +42,7 @@ describe('<LogInCard />', () => {
 
   describe('when the hide/show button is clicked', () => {
     it('changes the password input type to be text', async () => {
-      const wrapper = mount(LogInCard)
+      const wrapper = getLogInCardWrapper()
       const passwordInputElement = getHTMLElement(
         getByTestId(wrapper, 'password-input'),
       ) as HTMLInputElement
@@ -51,7 +57,7 @@ describe('<LogInCard />', () => {
 
   describe('when enter key is released on the password input field', () => {
     it('emits the close event', async () => {
-      const wrapper = mount(LogInCard)
+      const wrapper = getLogInCardWrapper()
 
       await getByTestId(wrapper, 'password-input').trigger('keyup.enter')
 
@@ -64,7 +70,7 @@ describe('<LogInCard />', () => {
     const password = 'homestarsux'
 
     it('emits the close event', async () => {
-      const wrapper = mount(LogInCard)
+      const wrapper = getLogInCardWrapper()
 
       await getByTestId(wrapper, 'login-button').trigger('click')
 
@@ -72,7 +78,7 @@ describe('<LogInCard />', () => {
     })
 
     it('clears the state', async () => {
-      const wrapper = mount(LogInCard)
+      const wrapper = getLogInCardWrapper()
 
       const emailInput = getByTestId(wrapper, 'email-input')
       const passwordInput = getByTestId(wrapper, 'password-input')
@@ -96,7 +102,7 @@ describe('<LogInCard />', () => {
 
     // this test is still failing
     it.skip('calls the api', async () => {
-      const wrapper = mount(LogInCard)
+      const wrapper = getLogInCardWrapper()
 
       const emailInput = getByTestId(wrapper, 'email-input')
       const passwordInput = getByTestId(wrapper, 'password-input')
@@ -136,7 +142,7 @@ describe('<LogInCard />', () => {
 
   describe('when the sign up button is clicked', () => {
     it('emits the sign up click event', async () => {
-      const wrapper = mount(LogInCard)
+      const wrapper = getLogInCardWrapper()
 
       await getByTestId(wrapper, 'sign-up-button').trigger('click')
 

--- a/components/blocks/cards/SignUpCard/SignUpCard.test.ts
+++ b/components/blocks/cards/SignUpCard/SignUpCard.test.ts
@@ -1,6 +1,12 @@
-import { mount } from '@vue/test-utils'
+import { mount, enableAutoUnmount } from '@vue/test-utils'
 import { getByTestId, getHTMLElement } from 'testUtils'
 import SignUpCard from './SignUpCard.vue'
+
+function getSignUpCardWrapper() {
+  return mount(SignUpCard)
+}
+
+enableAutoUnmount(afterEach)
 
 afterEach(() => {
   fetchMock.resetMocks()
@@ -9,14 +15,14 @@ afterEach(() => {
 
 describe('<SignUpCard />', () => {
   it('should render without crashing', () => {
-    const wrapper = mount(SignUpCard)
+    const wrapper = getSignUpCardWrapper()
 
     expect(wrapper.isVisible()).toBe(true)
   })
 
   describe('when the close button is clicked', () => {
     it('should emit the close event', async () => {
-      const wrapper = mount(SignUpCard)
+      const wrapper = getSignUpCardWrapper()
 
       await getByTestId(wrapper, 'close-button').trigger('click')
 
@@ -26,7 +32,7 @@ describe('<SignUpCard />', () => {
 
   describe('when the hide/show button is clicked', () => {
     it('changes the password input type to be text', async () => {
-      const wrapper = mount(SignUpCard)
+      const wrapper = getSignUpCardWrapper()
 
       const passwordInputElement = getHTMLElement(
         getByTestId(wrapper, 'password-input'),
@@ -47,7 +53,7 @@ describe('<SignUpCard />', () => {
 
   describe('when the login button is clicked', () => {
     it('emits the log in click event', async () => {
-      const wrapper = mount(SignUpCard)
+      const wrapper = getSignUpCardWrapper()
 
       await getByTestId(wrapper, 'login-button').trigger('click')
 
@@ -61,7 +67,7 @@ describe('<SignUpCard />', () => {
     const username = 'strongbad'
 
     it('emits the sign up click event', async () => {
-      const wrapper = mount(SignUpCard)
+      const wrapper = getSignUpCardWrapper()
 
       await getByTestId(wrapper, 'sign-up-button').trigger('click')
 
@@ -69,7 +75,7 @@ describe('<SignUpCard />', () => {
     })
 
     it('clears the state', async () => {
-      const wrapper = mount(SignUpCard)
+      const wrapper = getSignUpCardWrapper()
 
       const emailInputElement = getHTMLElement(
         getByTestId(wrapper, 'email-input'),
@@ -103,7 +109,7 @@ describe('<SignUpCard />', () => {
     })
 
     it('calls the api', async () => {
-      const wrapper = mount(SignUpCard)
+      const wrapper = getSignUpCardWrapper()
 
       await getByTestId(wrapper, 'email-input').setValue(emailAddress)
       await getByTestId(wrapper, 'username-input').setValue(username)

--- a/components/blocks/nav/SiteNavbar/SiteNavbar.test.ts
+++ b/components/blocks/nav/SiteNavbar/SiteNavbar.test.ts
@@ -1,24 +1,30 @@
-import { mount } from '@vue/test-utils'
+import { mount, enableAutoUnmount } from '@vue/test-utils'
 import * as apiComposables from 'composables/api'
 import { useCurrentUser } from 'composables/useCurrentUser'
 import { getByTestId } from 'testUtils'
 import SiteNavbar from './SiteNavbar.vue'
+
+function getSiteNavbarWrapper() {
+  return mount(SiteNavbar)
+}
 
 afterEach(() => {
   vi.restoreAllMocks()
   vi.clearAllMocks()
 })
 
+enableAutoUnmount(afterEach)
+
 describe('<SiteNavbar />', () => {
   it('should render without crashing', () => {
-    const wrapper = mount(SiteNavbar)
+    const wrapper = getSiteNavbarWrapper()
 
     expect(wrapper.isVisible()).toBe(true)
   })
 
   describe('when no user is logged in', () => {
     it('should render the login/sign up buttons', () => {
-      const wrapper = mount(SiteNavbar)
+      const wrapper = getSiteNavbarWrapper()
 
       expect(getByTestId(wrapper, 'site-navbar-login-button').isVisible()).toBe(
         true,
@@ -31,7 +37,7 @@ describe('<SiteNavbar />', () => {
 
     describe('when the login button is clicked', () => {
       it('should bring up the login card', () => {
-        const wrapper = mount(SiteNavbar)
+        const wrapper = getSiteNavbarWrapper()
 
         getByTestId(wrapper, 'site-navbar-login-button').trigger('click')
 
@@ -41,7 +47,7 @@ describe('<SiteNavbar />', () => {
 
     describe('when the sign up button is clicked', () => {
       it('should bring up the signup card', () => {
-        const wrapper = mount(SiteNavbar)
+        const wrapper = getSiteNavbarWrapper()
 
         getByTestId(wrapper, 'site-navbar-sign-up-button').trigger('click')
 
@@ -61,7 +67,7 @@ describe('<SiteNavbar />', () => {
     })
 
     it('should render the logout button', () => {
-      const wrapper = mount(SiteNavbar)
+      const wrapper = getSiteNavbarWrapper()
 
       expect(
         getByTestId(wrapper, 'site-navbar-logout-button').isVisible(),
@@ -72,7 +78,7 @@ describe('<SiteNavbar />', () => {
       const useLogoutUserSpy = vi.spyOn(apiComposables, 'useLogoutUser')
 
       it('should log out the user', async () => {
-        const wrapper = mount(SiteNavbar)
+        const wrapper = getSiteNavbarWrapper()
 
         await getByTestId(wrapper, 'site-navbar-logout-button').trigger('click')
 

--- a/components/elements/buttons/ButtonLink/ButtonLink.test.ts
+++ b/components/elements/buttons/ButtonLink/ButtonLink.test.ts
@@ -1,6 +1,8 @@
-import { mount } from '@vue/test-utils'
+import { mount, enableAutoUnmount } from '@vue/test-utils'
 
 import ButtonLink from './ButtonLink.vue'
+
+enableAutoUnmount(afterEach)
 
 describe('<ButtonLink />', () => {
   const defaultAttrs = { class: 'custom-link' }

--- a/components/elements/buttons/HideShowPassword/HideShowPassword.test.ts
+++ b/components/elements/buttons/HideShowPassword/HideShowPassword.test.ts
@@ -1,17 +1,23 @@
-import { mount } from '@vue/test-utils'
+import { mount, enableAutoUnmount } from '@vue/test-utils'
 import HideShowPassword from './HideShowPassword.vue'
 import { getByTestId, getHTMLElement } from 'testUtils'
 
+function getHideShowPassword() {
+  return mount(HideShowPassword)
+}
+
+enableAutoUnmount(afterEach)
+
 describe('<HideShowPassword />', () => {
   it('should render without crashing', () => {
-    const wrapper = mount(HideShowPassword)
+    const wrapper = getHideShowPassword()
 
     expect(wrapper.isVisible()).toBe(true)
   })
 
   describe('Visible eye, hidden eye, and the button', () => {
     it('should render without crashing', () => {
-      const wrapper = mount(HideShowPassword)
+      const wrapper = getHideShowPassword()
       const passwordButton = getByTestId(wrapper, 'hide-show-password-button')
       const hiddenEyeIcon = getByTestId(wrapper, 'hidden-eye-icon')
       const visibleEyeIcon = getByTestId(wrapper, 'visible-eye-icon')
@@ -24,7 +30,7 @@ describe('<HideShowPassword />', () => {
 
   describe('when clicking the button', () => {
     it('should toggle the state', async () => {
-      const wrapper = mount(HideShowPassword)
+      const wrapper = getHideShowPassword()
       const hiddenEyeIconElement = getHTMLElement(
         getByTestId(wrapper, 'hidden-eye-icon'),
       )
@@ -44,7 +50,7 @@ describe('<HideShowPassword />', () => {
 
   describe('when the button is focus and the enter key up event is triggered', () => {
     it('should toggle the state', async () => {
-      const wrapper = mount(HideShowPassword)
+      const wrapper = getHideShowPassword()
       const hiddenEyeIconElement = getHTMLElement(
         getByTestId(wrapper, 'hidden-eye-icon'),
       )

--- a/components/elements/modals/BaseModal/BaseModal.test.ts
+++ b/components/elements/modals/BaseModal/BaseModal.test.ts
@@ -1,31 +1,39 @@
-import { mount } from '@vue/test-utils'
+import { mount, enableAutoUnmount } from '@vue/test-utils'
 
 import BaseModal from './BaseModal.vue'
 
-describe('<BaseModal />', () => {
-  const BaseModalWrapper = mount(BaseModal, {
+function getBaseModalWrapper() {
+  return mount(BaseModal, {
     slots: { default: 'Modal content' },
   })
+}
 
+enableAutoUnmount(afterEach)
+
+describe('<BaseModal />', () => {
   it('should render without crashing', () => {
+    const BaseModalWrapper = getBaseModalWrapper()
     expect(BaseModalWrapper.isVisible()).toBe(true)
   })
 
   it('renders the correct <slot />', () => {
+    const BaseModalWrapper = getBaseModalWrapper()
     expect(BaseModalWrapper.html()).toContain('Modal content')
   })
 
   describe('when the close event is emitted', () => {
     it('when the close button is clicked', async () => {
+      const BaseModalWrapper = getBaseModalWrapper()
       await BaseModalWrapper.find('button').trigger('click')
 
       expect(BaseModalWrapper.emitted().close).toHaveLength(1)
     })
 
     it('when the escape key is released', async () => {
+      const BaseModalWrapper = getBaseModalWrapper()
       await BaseModalWrapper.find('button').trigger('keydown.esc')
 
-      expect(BaseModalWrapper.emitted().close).toHaveLength(2)
+      expect(BaseModalWrapper.emitted().close).toHaveLength(1)
     })
   })
 })

--- a/components/elements/nav/NavLinks/NavLink/NavLink.test.ts
+++ b/components/elements/nav/NavLinks/NavLink/NavLink.test.ts
@@ -1,17 +1,19 @@
-import { mount } from '@vue/test-utils'
+import { mount, enableAutoUnmount } from '@vue/test-utils'
 
 import NavLink from './NavLink.vue'
 
-describe('<NavLink />', () => {
-  const NavLinkWrapper = mount(NavLink, {
-    attrs: { class: 'custom-link' },
-    props: {
-      to: '/games',
-    },
-    slots: { default: 'Games' },
-  })
+enableAutoUnmount(afterEach)
 
+describe('<NavLink />', () => {
   it('should render without crashing', () => {
+    const NavLinkWrapper = mount(NavLink, {
+      attrs: { class: 'custom-link' },
+      props: {
+        to: '/games',
+      },
+      slots: { default: 'Games' },
+    })
+
     expect(NavLinkWrapper.isVisible()).toBe(true)
   })
 })

--- a/components/elements/nav/NavLinks/NavLinks.test.ts
+++ b/components/elements/nav/NavLinks/NavLinks.test.ts
@@ -1,26 +1,32 @@
-import { mount } from '@vue/test-utils'
+import { mount, enableAutoUnmount } from '@vue/test-utils'
 
 import NavLinks from './NavLinks.vue'
 
-describe('<NavLinks />', () => {
-  const props = {
-    navLinks: [
-      { name: 'Home', to: '/' },
-      { name: 'About', to: '/about' },
-      { name: 'Contact', to: '/contact' },
-    ],
-  }
+const props = {
+  navLinks: [
+    { name: 'Home', to: '/' },
+    { name: 'About', to: '/about' },
+    { name: 'Contact', to: '/contact' },
+  ],
+}
 
-  const NavLinksWrapper = mount(NavLinks, {
+function getNavLinksWrapper() {
+  return mount(NavLinks, {
     props,
   })
+}
 
+enableAutoUnmount(afterEach)
+
+describe('<NavLinks />', () => {
   it('should render without crashing', () => {
+    const NavLinksWrapper = getNavLinksWrapper()
     expect(NavLinksWrapper.isVisible()).toBe(true)
   })
 
   it('should render the same amount of <NavLink /> components as there are items in the navLinks props', () => {
     props.navLinks.forEach((navLink) => {
+      const NavLinksWrapper = getNavLinksWrapper()
       expect(NavLinksWrapper.html()).toContain(navLink.name)
     })
   })

--- a/pages/index.test.ts
+++ b/pages/index.test.ts
@@ -1,21 +1,27 @@
-import { mount } from '@vue/test-utils'
+import { mount, enableAutoUnmount } from '@vue/test-utils'
 
 import index from 'pages/index.vue'
 
-describe('/index', () => {
-  const IndexWrapper = mount(index, {
+function getIndexWrapper() {
+  return mount(index, {
     global: {
       mocks: {
         $t: (msg: any) => msg,
       },
     },
   })
+}
 
+enableAutoUnmount(afterEach)
+
+describe('/index', () => {
   it('should render without crashing', () => {
+    const IndexWrapper = getIndexWrapper()
     expect(IndexWrapper.isVisible()).toBe(true)
   })
 
   it('should render the placeholder text', () => {
+    const IndexWrapper = getIndexWrapper()
     expect(
       IndexWrapper.html().includes(
         'This is just a primary content placeholder.',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -43,7 +43,7 @@ export default mergeConfig(
       env: parsed,
       globals: true,
       sequence: {
-        shuffle: false, // change back to true later
+        shuffle: true,
       },
       setupFiles: ['vitest.setup.ts'],
     },


### PR DESCRIPTION
## What
Isolates the mounting of the compnents in tests to a given test instead of sharing as to prevent any false positive test passing.
Enabled `sequence.shuffle` to true so that the tests run in a random order to ensure that tests are not effecting eachother.

## Link to Issue

Closes https://github.com/leaderboardsgg/leaderboard-site/issues/534

## Acceptance

### Steps for testing

Run the tests quite a few times to ensure shuffle is working properly.
for your convienence
`pnpm test && pnpm test && pnpm test && pnpm test` 