### PR TITLE
Set packageManager to pnpm@7.29.0 (for Netlify builds)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "pnpm": ">=7.0.0"
   },
   "engineStrict": true,
+  "packageManager": "pnpm@7.29.0",
   "scripts": {
     "build": "nuxt build",
     "dev": "nuxt dev",


### PR DESCRIPTION
## What

### Context
This is the only frontend repo change required for the development environment setup hosted on Netlify and fly.io.
A backend repo PR will follow for the fly.io setup.

### Change
Added the `packageManager` field to package.json to specify the pnpm version used by Corepack.
Netlify builds using Corepack, and when it tries to build using its default pnpm version (7.13.4) it seems to not install dependencies correctly.

### Build log without my change
https://app.netlify.com/sites/cheery-empanada-be861b/deploys/64190937a8aecf24abe42b7c
```
10:32:57 AM: Installing npm packages using pnpm version 7.13.4
10:32:57 AM:  WARN  Ignoring not compatible lockfile at /opt/build/repo/pnpm-lock.yaml
[...]
10:33:33 AM: [error] [vite]: Rollup failed to resolve import "/opt/build/repo/node_modules/.pnpm/vue-i18n@9.3.0-beta.14-77e850b_vue@3.2.47/node_modules/dist/vue-i18n.runtime.mjs" from "/opt/build/repo/components/blocks/SiteFooter/LanguageSelector/LanguageSelector.vue?vue&type=script&setup=true&lang.ts".
10:33:33 AM: This is most likely unintended because it can break your application at runtime.
10:33:33 AM: If you do want to externalize this module explicitly add it to
10:33:33 AM: `build.rollupOptions.external`
10:33:33 AM: [error] [vite]: Rollup failed to resolve import "/opt/build/repo/node_modules/.pnpm/vue-i18n@9.3.0-beta.14-77e850b_vue@3.2.47/node_modules/dist/vue-i18n.runtime.mjs" from "/opt/build/repo/components/blocks/SiteFooter/LanguageSelector/LanguageSelector.vue?vue&type=script&setup=true&lang.ts".
```

### Build log with my change
https://app.netlify.com/teams/dalet/builds/641913ed30e36c0008c1bc77
```
11:18:35 AM: Installing npm packages using pnpm version 7.29.0
11:18:36 AM: Lockfile is up to date, resolution step is skipped
[...]
11:19:14 AM: Site is live ✨
11:19:15 AM: Build script success
11:19:15 AM: Section completed: building
11:19:16 AM: Uploading Cache of size 196.4MB
11:19:18 AM: Section completed: cleanup
11:19:18 AM: Finished processing build request in 53.804s
```

## Acceptance

### Steps for testing
Try to deploy on Netlify.
This PR's branch is live at https://netlify--cheery-empanada-be861b.netlify.app/