### PR TITLE
LBGG: Auto update API

### DIFF
--- a/.github/workflows/update-api.yml
+++ b/.github/workflows/update-api.yml
@@ -97,7 +97,7 @@ jobs:
           pnpm pretty:staged
           git add ./lib
           git commit -m 'chore: lib: update api' --no-verify
-          git remote set-url origin https://api-updater:${{ secrets.GITHUB_TOKEN }}@github.com/leaderboardsgg/leaderboard-site.git
+          git remote set-url origin https://api-updater:${{ secrets.GITHUB_TOKEN }}@github.com/erunks/leaderboard-site.git
           git push origin ${{ steps.branch.outputs.BRANCH_NAME }}
 
       - name: Create PR

--- a/.github/workflows/update-api.yml
+++ b/.github/workflows/update-api.yml
@@ -3,7 +3,10 @@ name: Update API
 on:
   workflow_dispatch:
 
-permissions: write-all
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/update-api.yml
+++ b/.github/workflows/update-api.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Create PR
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.WORKFLOW_ACCESS_TOKEN }}
           script: |
             await github.rest.pulls.create({
               owner: 'erunks',

--- a/.github/workflows/update-api.yml
+++ b/.github/workflows/update-api.yml
@@ -96,7 +96,7 @@ jobs:
           pnpm pretty:staged
           git add ./lib
           git commit -m 'chore: lib: update api' --no-verify
-          git remote set-url origin https://api-updater:${{ secrets.GITHUB_TOKEN }}@github.com/erunks/leaderboard-site.git
+          git remote set-url origin https://api-updater:${{ secrets.GITHUB_TOKEN }}@github.com/leaderboardsgg/leaderboard-site.git
           git push origin ${{ steps.branch.outputs.BRANCH_NAME }}
 
       - name: Create PR
@@ -105,7 +105,7 @@ jobs:
           github-token: ${{ secrets.WORKFLOW_ACCESS_TOKEN }}
           script: |
             await github.rest.pulls.create({
-              owner: 'erunks',
+              owner: 'leaderboardsgg',
               repo: 'leaderboard-site',
               base: 'main',
               head: '${{ steps.branch.outputs.BRANCH_NAME }}',

--- a/.github/workflows/update-api.yml
+++ b/.github/workflows/update-api.yml
@@ -3,11 +3,7 @@ name: Update API
 on:
   workflow_dispatch:
 
-permissions:
-  actions: read
-  contents: write
-  pull-requests: write
-  repository-projects: write
+permissions: write-all
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/update-api.yml
+++ b/.github/workflows/update-api.yml
@@ -1,0 +1,114 @@
+name: Update API
+
+on:
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: write
+  pull-requests: write
+  repository-projects: write
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  update-api:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+
+      - name: Read package.json
+        id: package
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: ./package.json
+
+      # Ensures pnpm version is consistent and gets back the value to be used in pnpm setup action
+      - name: Get PNPM version
+        id: pnpm-version
+        uses: buffet-time/pnpm-versions-check-action@v1.2
+        with:
+          # engines.pnpm
+          packageJson-engines-pnpm: '${{ fromJson(steps.package.outputs.content).engines.pnpm }}'
+
+          # packageManager
+          packageJson-packageManager: '${{ fromJson(steps.package.outputs.content).packageManager }}'
+
+      - name: Cache PNPM modules
+        uses: actions/cache@v3
+        id: cache-modules
+        with:
+          path: |
+            ~/.pnpm-store
+            node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-node-
+
+      - uses: pnpm/action-setup@v2.2.4
+        with:
+          version: '${{ steps.pnpm-version.outputs.version }}'
+
+      - uses: actions/setup-node@v3
+        with:
+          # use the version found in `.nvmrc`
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      # shows current pnpm version
+      - name: check pnpm version
+        run: pnpm -v
+
+      - name: Install `node_modules`
+        if: steps.cache-modules.outputs.cache-hit != 'true'
+        run: pnpm install
+
+      - name: Copy `.env.test` -> `.env`
+        run: cp .env.test .env
+
+      - name: Cache build
+        uses: actions/cache@v3
+        id: cache-build
+        with:
+          path: .nuxt/
+          key: ${{ runner.os }}-build-${{ hashFiles('**/.nuxt') }}
+          restore-keys: ${{ runner.os }}-build-
+
+      - name: Build the `.nuxt` directory
+        if: steps.cache-build.outputs.cache-hit != 'true'
+        run: pnpm build
+
+      - name: Run the API generation
+        run: pnpm run generate:api --url=${{ vars.OPENAPI_URL }}
+
+      - name: Set git configs
+        run: |
+          git config user.email "api-updater@leaderboards.gg"
+          git config user.name "API Updater"
+
+      - name: Set branch name
+        id: branch
+        run: echo "BRANCH_NAME=chore-update-api-$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Add changes, commit, and push
+        run: |
+          git checkout -b ${{ steps.branch.outputs.BRANCH_NAME }}
+          pnpm pretty:staged
+          git add ./lib
+          git commit -m 'chore: lib: update api' --no-verify
+          git remote set-url origin https://api-updater:${{ secrets.GITHUB_TOKEN }}@github.com/leaderboardsgg/leaderboard-site.git
+          git push origin ${{ steps.branch.outputs.BRANCH_NAME }}
+
+      - name: Create PR
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.pulls.create({
+              owner: 'leaderboardsgg',
+              repo: 'leaderboard-site',
+              base: 'main',
+              head: '${{ steps.branch.outputs.BRANCH_NAME }}',
+              title: 'chore: Update API',
+            })

--- a/.github/workflows/update-api.yml
+++ b/.github/workflows/update-api.yml
@@ -106,7 +106,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             await github.rest.pulls.create({
-              owner: 'leaderboardsgg',
+              owner: 'erunks',
               repo: 'leaderboard-site',
               base: 'main',
               head: '${{ steps.branch.outputs.BRANCH_NAME }}',

--- a/scripts/generate-api.js
+++ b/scripts/generate-api.js
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-/* eslint-dsiable no-console */
+/* eslint-disable no-console */
 /* eslint-disable vue/sort-keys */
 
 /*
@@ -11,13 +11,26 @@
  * path specified by the `output` argument.
  */
 
+const args = process.argv.reduce((acc, current) => {
+  if (current.includes('=')) {
+    const [key, value] = current.substring(2).split('=')
+    acc[key] = value
+  }
+
+  return acc
+}, {})
+
 require('dotenv-safe').config()
 const { resolve } = require('path')
 const { generateApi } = require('swagger-typescript-api')
+const url =
+  args?.url ?? `${process.env.BACKEND_BASE_URL}/swagger/v1/swagger.json`
+
+console.log(`Generation url: ${url}`)
 
 generateApi({
   output: resolve(process.cwd(), './lib/api'),
-  url: `${process.env.BACKEND_BASE_URL}/swagger/v1/swagger.json`,
+  url,
 
   enumNamesAsValues: true,
   extractRequestBody: true,


### PR DESCRIPTION
## What
In order to keep the API in sync better with the changes being made on https://github.com/leaderboardsgg/leaderboard-backend, this PR adds 1/2 of the workflow actions that will automatically create a PR for us with all the API changes that were introduced from new code being pushed to `main`.

## Requirements
Needs the following things to run:
  - repo variable `OPENAPI_URL`
    - this is what points the `pnpm generate:api` command at the right `openapi` spec file to read 
  - repo secret `WORKFLOW_ACCESS_TOKEN`
    - this is what allows the `actions/github-script` to actually create our PR for us
    - note that the `permissions` specified in the workflow are only used for the other `git` actions, such as committing and pushing the actual changes to the branch we create

## Changes
- Added:
  -  new `update-api` workflow to auto create a PR with the latest API changes from the backend repo
- Updated:
  - `generate-api` script, to accept a passed URL as an option to generate off

## Link to Issue

Closes https://github.com/leaderboardsgg/leaderboard-site/issues/559

## Acceptance

### Steps for testing

- Successful run on my fork of the backend repo: https://github.com/erunks/leaderboard-backend/actions/runs/5404668272
- Successful trigger on my fork of the frontend repo: https://github.com/erunks/leaderboard-site/actions/runs/5404338702
  - PR that was spun off from the frontend workflow: https://github.com/erunks/leaderboard-site/pull/3

