### PR TITLE
Prevent login modal from showing when user clicks logout 

### DIFF
--- a/components/blocks/nav/SiteNavbar/SiteNavbar.vue
+++ b/components/blocks/nav/SiteNavbar/SiteNavbar.vue
@@ -67,6 +67,7 @@ function toggleSignUpModal() {
 
 function logout() {
   useLogoutUser()
+  state.showModal = false
 }
 </script>
 
@@ -102,7 +103,6 @@ function logout() {
           @click="logout"
           @keyup.enter="logout"
         />
-
         <button class="mobile-menu__toggle" @click="toggleMenu">
           <i-svg-menu class="mx-2 size-5 fill-current" />
         </button>


### PR DESCRIPTION
## What

Added state.showModal = false in the logout() function, to ensure the state is false even if there is any possible event propagation 

## Link to Issue

Closes [this issue](https://github.com/leaderboardsgg/leaderboard-site/issues/595)

## Acceptance

### Steps for testing

Log out user should not show the login modal

### Images

Any images of the Components/UI that were worked on
