### PR TITLE
Draft: Don't Print "Success!" For Endpoints that Don't Guarantee It

### DIFF
--- a/components/blocks/cards/ForgotPasswordCard/ForgotPasswordCard.vue
+++ b/components/blocks/cards/ForgotPasswordCard/ForgotPasswordCard.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
-import { type Ref, ref } from 'vue'
-import { isEmailValid, isUsernameValid } from 'lib/form_helpers'
-import BaseButton from 'elements/buttons/BaseButton/BaseButton.vue'
-import BaseInput from 'elements/inputs/BaseInput/BaseInput.vue'
-import CloseButton from 'elements/buttons/CloseButton/CloseButton.vue'
-import CardBody from 'elements/cards/CardBody/CardBody.vue'
-import CardHeader from 'elements/cards/CardHeader/CardHeader.vue'
-import Card from 'elements/cards/Card/Card.vue'
+import { ref, type Ref } from 'vue'
 import { useRecoverAccount } from 'composables/api'
 import { useModalAlert } from 'composables/useModalAlert'
+import BaseButton from 'elements/buttons/BaseButton/BaseButton.vue'
+import CloseButton from 'elements/buttons/CloseButton/CloseButton.vue'
+import Card from 'elements/cards/Card/Card.vue'
+import CardBody from 'elements/cards/CardBody/CardBody.vue'
+import CardHeader from 'elements/cards/CardHeader/CardHeader.vue'
+import BaseInput from 'elements/inputs/BaseInput/BaseInput.vue'
+import { isEmailValid, isUsernameValid } from 'lib/form_helpers'
 
 interface ForgotPasswordCardPops {
   modal?: boolean
@@ -61,8 +61,8 @@ function resetPassword() {
 
         showAlert({
           body: 'If an account with that email and username exists, we will send you an email with a link to reset your password.',
-          title: 'Success!',
-          type: 'success',
+          title: 'Password Recovery',
+          type: 'info',
         })
       },
     },

--- a/composables/api/useRecoverAccount/index.ts
+++ b/composables/api/useRecoverAccount/index.ts
@@ -1,5 +1,6 @@
-import { ApiResponse, optionalParameters, useApi } from 'composables/useApi'
+import { useApi } from 'composables/useApi'
 import { Account } from 'lib/api/Account'
+import type { ApiResponse, optionalParameters } from 'composables/useApi'
 import type { RecoverAccountRequest } from 'lib/api/data-contracts'
 
 export async function useRecoverAccount(

--- a/composables/useModalAlert.ts
+++ b/composables/useModalAlert.ts
@@ -2,7 +2,7 @@ interface ModalAlertState {
   body: string
   show: boolean
   title: string
-  type: string
+  type: 'info' | 'success' | 'warning' | 'error' | ''
   onClose?: () => void
 }
 


### PR DESCRIPTION
## What

Changes the modal title of when the user submits an account recovery.

## Link to Issue

Closes https://github.com/leaderboardsgg/leaderboard-site/issues/594

## Acceptance

### Steps for testing

Verify that the modal title does not print "Success!"

### Images

TODO
