### PR TITLE
bug/LBGG-590: Persistent login

### DIFF
--- a/composables/useCurrentUser.ts
+++ b/composables/useCurrentUser.ts
@@ -1,10 +1,14 @@
+import { useCookie } from 'nuxt/app'
 import type { UserViewModel } from 'lib/api/data-contracts'
+import type { CookieRef } from 'nuxt/app'
 
-export function useCurrentUser() {
-  return useState<UserViewModel>('current_user', () => ({
-    id: '',
-    username: '',
-  }))
+export function useCurrentUser(): CookieRef<UserViewModel> {
+  return useCookie('current_user', {
+    default: () => ({
+      id: '',
+      username: '',
+    }),
+  })
 }
 
 export default useCurrentUser

--- a/composables/useCurrentUser.ts
+++ b/composables/useCurrentUser.ts
@@ -1,4 +1,3 @@
-import { useCookie } from 'nuxt/app'
 import type { UserViewModel } from 'lib/api/data-contracts'
 import type { CookieRef } from 'nuxt/app'
 

--- a/composables/useSessionToken.ts
+++ b/composables/useSessionToken.ts
@@ -1,5 +1,8 @@
-export function useSessionToken() {
-  return useState<string>('session_token')
+import { useCookie } from 'nuxt/app'
+import type { CookieRef } from 'nuxt/app'
+
+export function useSessionToken(): CookieRef<string> {
+  return useCookie<string>('session_token')
 }
 
 export default useSessionToken

--- a/composables/useSessionToken.ts
+++ b/composables/useSessionToken.ts
@@ -1,4 +1,3 @@
-import { useCookie } from 'nuxt/app'
 import type { CookieRef } from 'nuxt/app'
 
 export function useSessionToken(): CookieRef<string> {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -11,6 +11,25 @@ const fetchMock = createFetchMock(vi)
 // sets globalThis.fetch and globalThis.fetchMock to our mocked version
 fetchMock.enableMocks()
 
+const cookies = reactive<{ [key: string]: any }>({})
+interface CookieOptions {
+  default?: () => any
+}
+
+export const useCookieMock = vi.fn((key: string, opts?: CookieOptions) => {
+  const cookie = toRef(cookies, key)
+  if (cookie.value === undefined && opts?.default) {
+    const initialValue = opts.default()
+    if (isRef(initialValue)) {
+      cookies[key] = initialValue
+      return initialValue as Ref<any>
+    }
+    cookie.value = initialValue
+  }
+  return cookie
+})
+vi.stubGlobal('useCookie', useCookieMock)
+
 // Stolen from here:
 // https://zenn.dev/ninebolt6/articles/cadc924cb2416d
 const payload = reactive<{ state: Record<string, any> }>({


### PR DESCRIPTION
## What
Enables persistent logins across multiple tabs and windows by storing session data in a cookie

### Changes
- Use a cookie to store the 
  - current user.
  - session token.
- Mocked `useCookie` out in the tests

## Link to Issue

Closes https://github.com/leaderboardsgg/leaderboard-site/issues/590

## Acceptance

### Steps for testing
- [ ] Log in to an account
- [ ] Open a new tab
- [ ] Verify you are still logged in
