### PR TITLE
Use localStorage for Session Token

### DIFF
--- a/composables/api/useLogoutUser/useLogoutUser.test.ts
+++ b/composables/api/useLogoutUser/useLogoutUser.test.ts
@@ -2,13 +2,24 @@ import { useCurrentUser, useSessionToken } from '#imports'
 import type { UserViewModel } from 'lib/api/data-contracts'
 import useLogoutUser from '.'
 
-const token = 'auth-token'
+let token = ''
 const user: UserViewModel = {
   id: '575888bd-9702-41a9-9b75-fc87d785c22a',
   role: 'Confirmed',
   username: 'test',
   createdAt: '1984-01-01T00:00:00Z',
 }
+
+vi.mock('@vueuse/core', () => ({
+  useLocalStorage: () => ({
+    get value() {
+      return token
+    },
+    set value(val) {
+      token = val
+    },
+  }),
+}))
 
 afterEach(() => {
   fetchMock.resetMocks()
@@ -19,14 +30,14 @@ afterEach(() => {
 describe('useLogoutUser', () => {
   beforeEach(() => {
     fetchMock.mockIf(/.*\/[Uu]ser\/me/, () => JSON.stringify(user))
-    useSessionToken().value = token
+    token = 'auth-token'
   })
 
   it('sets the `authToken` and `currentUser` back to the default values', async () => {
     const authToken = useSessionToken()
     const { data, refresh } = await useCurrentUser()
 
-    expect(authToken.value).toEqual(token)
+    expect(authToken.value).toEqual('auth-token')
     expect(data.value).toEqual(user)
 
     useLogoutUser()

--- a/composables/useSessionToken.ts
+++ b/composables/useSessionToken.ts
@@ -1,7 +1,5 @@
-import { useCookie } from '#imports'
+import { useLocalStorage } from '@vueuse/core'
 
 export default function useSessionToken() {
-  return useCookie('session_token', {
-    default: () => '',
-  })
+  return useLocalStorage<string>('session', '')
 }


### PR DESCRIPTION
## What

Use localStorage instead of cookie storage for the session token.

## Link to Issue

Closes #653 

## Acceptance

### Steps for testing

User can log in and out. Logins are not scoped to one browser tab. User stays logged in between browser sessions.