### PR TITLE
SiteNavbar: Allow toggling of modals when using the keyboard

### DIFF
--- a/components/blocks/nav/SiteNavbar/SiteNavbar.vue
+++ b/components/blocks/nav/SiteNavbar/SiteNavbar.vue
@@ -87,19 +87,16 @@ function logout() {
           v-if="!loggedIn"
           data-testid="site-navbar-login-button"
           @click="toggleLoginModal"
-          @keyup.enter="toggleLoginModal"
         />
         <SignUpButton
           v-if="!loggedIn"
           data-testid="site-navbar-sign-up-button"
           @click="toggleSignUpModal"
-          @keyup.enter="toggleSignUpModal"
         />
         <LogoutButton
           v-if="loggedIn"
           data-testid="site-navbar-logout-button"
           @click="logout"
-          @keyup.enter="logout"
         />
         <button class="mobile-menu__toggle" @click="toggleMenu">
           <i-svg-menu class="mx-2 size-5 fill-current" />


### PR DESCRIPTION
## What

Users who prefer to use the keyboard should be allowed to open the
sign up and log in modals.

For this to work only one handler should be present, and not be in
conflict with another one.

By removing the "keyup.enter" handler it allows keyboard users to click
the modal without it being toggled back off right away.

In addition, the logout button does not need a keyup.enter handler
either, as it does the same thing as the click handler.

## Link to Issue

None

## Acceptance

### Steps for testing

1. Use the tab, shift+tab shortcuts to navigate to the sign up or log in
   buttons in the navbar
2. Press enter
3. Observe how the modal does not open and close, but instead opens and
   stays open

This does not affect the current behaviour of "space", which worked
before and still works now.

### Images

None
