### PR TITLE
feat: add runStats to leaderboards and make grid css dynamic

### DIFF
--- a/app/components/blocks/Landing/Landing.vue
+++ b/app/components/blocks/Landing/Landing.vue
@@ -2,18 +2,17 @@
 import LandingLeaderboards from './LandingLeaderboards.vue'
 import LandingAbout from './LandingAbout.vue'
 import { useGetLeaderboards } from '~/composables/api'
-
 import Loader from 'blocks/Loader/Loader.vue'
 
-const leaderboards = await useGetLeaderboards()
+const { data: leaderboards, loading } = await useGetLeaderboards()
 </script>
 
 <template>
   <div>
     <h2 class="mb-4 text-3xl font-bold">Games</h2>
     <div class="flex flex-col lg:flex-row">
-      <Loader v-if="leaderboards.loading"></Loader>
-      <LandingLeaderboards :leaderboards="leaderboards.data?.data || []" />
+      <Loader v-if="loading"></Loader>
+      <LandingLeaderboards :leaderboards="leaderboards?.data || []" />
       <LandingAbout />
     </div>
   </div>

--- a/app/components/blocks/Landing/LandingLeaderboards.test.ts
+++ b/app/components/blocks/Landing/LandingLeaderboards.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import LandingLeaderboards from './LandingLeaderboards.vue'
-import type { LeaderboardViewModel } from '~/lib/api/data-contracts'
+import type { LeaderboardViewModel } from '~~/lib/api/data-contracts'
 
 const games: LeaderboardViewModel[] = [
   {
@@ -11,27 +11,36 @@ const games: LeaderboardViewModel[] = [
     createdAt: '2024-11-02T22:11:08+0000',
     updatedAt: '2024-11-02T22:11:08+0000',
     deletedAt: null,
-    categories: [],
+    status: 'Published',
+    stats: {
+      runCount: 42,
+    },
   },
   {
     id: 2,
-    name: 'Getting Over It With Bennet Foddy',
+    name: 'Ocarine of Time',
     slug: 'slug-2',
     info: '',
     createdAt: '2024-11-02T22:11:08+0000',
     updatedAt: '2024-11-02T22:11:08+0000',
     deletedAt: null,
-    categories: [],
+    status: 'Published',
+    stats: {
+      runCount: 64,
+    },
   },
   {
     id: 3,
-    name: 'Getting Over It With Bennet Foddy',
+    name: 'Mario 64',
     slug: 'slug-3',
     info: '',
     createdAt: '2024-11-02T22:11:08+0000',
     updatedAt: '2024-11-02T22:11:08+0000',
     deletedAt: null,
-    categories: [],
+    status: 'Published',
+    stats: {
+      runCount: 4,
+    },
   },
 ]
 
@@ -44,12 +53,55 @@ describe('LandingLeaderboards Component', () => {
     })
 
     expect(wrapper.isVisible()).toBe(true)
+  })
 
-    wrapper
-      .getComponent('div#landing-leaderboards')
-      .findAllComponents('div')
-      .forEach((c, i) => {
-        expect(c.text()).toBe(games[i])
+  it.each(games)(
+    'should render game name "$name" in leaderboard card',
+    async (game) => {
+      const wrapper = await mountSuspended(LandingLeaderboards, {
+        props: {
+          leaderboards: games,
+        },
       })
+
+      expect(wrapper.html()).toContain(game.name)
+    },
+  )
+
+  it.each(games)(
+    'should render run stats for "$name" in leaderboard card',
+    async (game) => {
+      const wrapper = await mountSuspended(LandingLeaderboards, {
+        props: {
+          leaderboards: games,
+        },
+      })
+
+      expect(wrapper.html()).toContain(game?.stats?.runCount)
+    },
+  )
+
+  it('should not render stats for leaderboard if stats are falsy', async () => {
+    const mockLeaderBoardsWithoutStats: LeaderboardViewModel[] = [
+      {
+        id: 1,
+        name: 'Getting Over It With Bennet Foddy',
+        slug: 'slug-2',
+        info: '',
+        createdAt: '2024-11-02T22:11:08+0000',
+        updatedAt: '2024-11-02T22:11:08+0000',
+        deletedAt: null,
+        status: 'Published',
+        stats: {},
+      },
+    ]
+
+    const wrapper = await mountSuspended(LandingLeaderboards, {
+      props: {
+        leaderboards: mockLeaderBoardsWithoutStats,
+      },
+    })
+
+    expect(wrapper.html()).not.toContain('runs')
   })
 })

--- a/app/components/blocks/Landing/LandingLeaderboards.vue
+++ b/app/components/blocks/Landing/LandingLeaderboards.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import type { LeaderboardViewModel } from '~~/lib/api/data-contracts'
-import { useLocalePath } from '#imports'
-const localePath = useLocalePath()
+import LandingLeaderboardsCard from './LandingLeaderboardsCard.vue'
 
 interface LandingLeaderboardsProps {
   leaderboards: LeaderboardViewModel[]
@@ -10,24 +9,33 @@ interface LandingLeaderboardsProps {
 defineProps<LandingLeaderboardsProps>()
 </script>
 <template>
-  <div
-    id="landing-leaderboards"
-    class="mb-4 grid w-full grid-cols-1 content-start items-start gap-4 lg:grid-cols-2"
-  >
-    <NuxtLink
-      v-for="leaderboard in leaderboards"
-      :key="leaderboard.id"
-      class="mb-2 h-full content-center rounded-lg bg-gray-200 p-8 text-blue-500 underline hover:cursor-pointer"
-      :to="
-        localePath({
-          name: 'game-slug',
-          params: { slug: leaderboard.slug },
-        })
-      "
-    >
-      <span class="contents break-words font-bold">
-        {{ leaderboard?.name }}
-      </span>
-    </NuxtLink>
+  <div id="landing-leaderboards" class="leaderboards-grid w-full">
+    <LandingLeaderboardsCard
+      v-for="{ id, name, slug, stats } in leaderboards"
+      :id="id"
+      :key="id"
+      :name="name"
+      :slug="slug"
+      :stats="stats"
+    />
   </div>
 </template>
+
+<style lang="postcss" scoped>
+.leaderboards-grid {
+  --grid-col-min-size: 200px;
+  --grid-item-max-height: 330px;
+
+  display: grid;
+  grid-template-columns: repeat(
+    auto-fill,
+    minmax(min(var(--grid-col-min-size), 100%), 1fr)
+  );
+  grid-auto-rows: min-content;
+  gap: 1rem;
+
+  > * {
+    max-height: var(--grid-item-max-height);
+  }
+}
+</style>

--- a/app/components/blocks/Landing/LandingLeaderboardsCard.vue
+++ b/app/components/blocks/Landing/LandingLeaderboardsCard.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import type { LeaderboardViewModel } from 'lib/api/data-contracts'
+import { useLocalePath } from '#imports'
+const localePath = useLocalePath()
+
+const { id, slug, name, stats } =
+  defineProps<Pick<LeaderboardViewModel, 'id' | 'slug' | 'name' | 'stats'>>()
+</script>
+
+<template>
+  <NuxtLink
+    :key="id"
+    class="flex flex-col bg-gray-200 text-blue-500 underline hover:cursor-pointer"
+    :to="localePath({ name: 'game-slug', params: { slug: slug } })"
+  >
+    <!-- TODO: replace span with image tag when backend returns image from model -->
+    <span class="h-[250px] w-full flex-shrink object-cover" />
+    <div class="p-2">
+      <span class="block break-words font-bold"> {{ name }} </span>
+      <span v-if="stats?.runCount">{{ stats.runCount }} runs</span>
+    </div>
+  </NuxtLink>
+</template>


### PR DESCRIPTION
## What
Grid will fit as many items in there that fit ` --grid-col-min-size: 200px;` and grow `1fr` until another one fits of min-size which can of course be adjusted. I just eyeballed the design. 

- [x] https://github.com/leaderboardsgg/leaderboard-site/pull/665

## Link to Issue

Closes https://github.com/leaderboardsgg/leaderboard-site/issues/699

## Acceptance

### Steps for testing

There's no runs currently configured so you'd have to manually set them up OR go into vue dev tools and plus them there.

<img width="395" height="370" alt="Screenshot 2025-12-08 at 19 50 45" src="https://github.com/user-attachments/assets/ff299400-a0d1-4f67-86a7-e968fa865c94" />

### Images

https://github.com/user-attachments/assets/0c274df8-a2ed-4b7b-9c17-2b5f547b8b45